### PR TITLE
Use streaming transfers

### DIFF
--- a/torchft/checkpointing_test.py
+++ b/torchft/checkpointing_test.py
@@ -4,11 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
 import urllib.error
 from unittest import TestCase
 from unittest.mock import MagicMock
-
-from torchft.checkpointing import CheckpointServer
+from io import BytesIO
+import torch
+from typing import Tuple
+from checkpointing import CheckpointServer, TensorMetadata, write_state_dict, read_state_dict
 
 
 class TestCheckpointing(TestCase):
@@ -33,3 +36,67 @@ class TestCheckpointing(TestCase):
             CheckpointServer.load_from_address(addr)
 
         server.shutdown()
+
+    def setUp(self):
+        self.file = BytesIO()
+
+    def test_scalar_tensor(self):
+        tensor = torch.tensor(42, dtype=torch.int32)
+        state_dict = {'scalar': tensor}
+        write_state_dict(state_dict, self.file)
+        self.file.seek(0)
+
+        result = read_state_dict(self.file)
+        self.assertTrue(torch.equal(result['scalar'], tensor))
+
+    def test_strided_tensor(self):
+        base_tensor = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+        strided_tensor = base_tensor[::2, ::2]
+        state_dict = {'strided': strided_tensor}
+        write_state_dict(state_dict, self.file)
+        self.file.seek(0)
+
+        result = read_state_dict(self.file)
+        self.assertTrue(torch.equal(result['strided'], strided_tensor))
+
+    def test_tensor_with_offset(self):
+        base_tensor = torch.arange(10, dtype=torch.float64)
+        offset_tensor = base_tensor[2:]
+        state_dict = {'offset': offset_tensor}
+        write_state_dict(state_dict, self.file)
+        self.file.seek(0)
+
+        result = read_state_dict(self.file)
+        self.assertTrue(torch.equal(result['offset'], offset_tensor))
+
+    def test_nested_tensors(self):
+        tensor1 = torch.tensor([1, 2, 3], dtype=torch.int32)
+        tensor2 = torch.tensor([[1.5, 2.5], [3.5, 4.5]], dtype=torch.float64)
+        state_dict = {'nested': {'tensor1': tensor1, 'tensor2': tensor2}}
+        write_state_dict(state_dict, self.file)
+        self.file.seek(0)
+
+        result = read_state_dict(self.file)
+        self.assertTrue(torch.equal(result['nested']['tensor1'], tensor1))
+        self.assertTrue(torch.equal(result['nested']['tensor2'], tensor2))
+
+    def test_various_data_types(self):
+        tensor_float32 = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+        tensor_int16 = torch.tensor([1, 2, 3], dtype=torch.int16)
+        tensor_bool = torch.tensor([True, False, True], dtype=torch.bool)
+        state_dict = {
+            'float32': tensor_float32,
+            'int16': tensor_int16,
+            'bool': tensor_bool,
+        }
+        write_state_dict(state_dict, self.file)
+        self.file.seek(0)
+
+        result = read_state_dict(self.file)
+        self.assertTrue(torch.equal(result['float32'], tensor_float32))
+        self.assertTrue(torch.equal(result['int16'], tensor_int16))
+        self.assertTrue(torch.equal(result['bool'], tensor_bool))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1) Added the the write_state_dict and read_state_dict implementations into checkpointing.py

2) Replaced existing torch.save/torch.load with those

3)Added unit tests for write_state_dict/read_state_dict for all the different possible types of torch tensors

4) Added checksum to read/write_state_dict that uses zlib.crc32