### PR TITLE
[manager] fix address when binding to 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl Manager {
         py: Python<'_>,
         replica_id: String,
         lighthouse_addr: String,
-        address: String,
+        hostname: String,
         bind: String,
         store_addr: String,
         world_size: u64,
@@ -52,7 +52,7 @@ impl Manager {
                 .block_on(manager::Manager::new(
                     replica_id,
                     lighthouse_addr,
-                    address,
+                    hostname,
                     bind,
                     store_addr,
                     world_size,

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -100,6 +100,7 @@ class Manager:
         lighthouse_addr: Optional[str] = None,
         replica_id: Optional[str] = None,
         port: Optional[int] = None,
+        hostname: str = socket.gethostname(),
     ) -> None:
         """
         Args:
@@ -122,6 +123,7 @@ class Manager:
             store_port: TCPStore port for this replica group
             lighthouse_addr: if rank==0, the address of the lighthouse server
             replica_id: if rank==0, the replica_id for this group
+            hostname: if rank==0, the hostname to advertise to the lighthouse server
         """
         self._load_state_dict = load_state_dict
         self._state_dict = state_dict
@@ -159,12 +161,9 @@ class Manager:
         self._manager: Optional[_Manager] = None
 
         if rank == 0:
-            hostname = socket.gethostname()
-
             if port is None:
                 port = int(os.environ.get(MANAGER_PORT_ENV, 0))
 
-            addr = f"http://{hostname}:{port}"
             bind = f"[::]:{port}"
             lighthouse_addr = lighthouse_addr or os.environ["TORCHFT_LIGHTHOUSE"]
 
@@ -174,7 +173,7 @@ class Manager:
             self._manager = _Manager(
                 replica_id=replica_id,
                 lighthouse_addr=lighthouse_addr,
-                address=addr,
+                hostname=hostname,
                 bind=bind,
                 store_addr=f"{store_addr}:{store_port}",
                 world_size=world_size,

--- a/torchft/torchft.pyi
+++ b/torchft/torchft.pyi
@@ -27,7 +27,7 @@ class Manager:
         self,
         replica_id: str,
         lighthouse_addr: str,
-        address: str,
+        hostname: str,
         bind: str,
         store_addr: str,
         world_size: int,
@@ -36,6 +36,12 @@ class Manager:
     def shutdown(self) -> None: ...
 
 class Lighthouse:
-    def __init__(self, bind: str, min_replicas: int, join_timeout_ms: Optional[int] = None, quorum_tick_ms: Optional[int] = None) -> None: ...
+    def __init__(
+        self,
+        bind: str,
+        min_replicas: int,
+        join_timeout_ms: Optional[int] = None,
+        quorum_tick_ms: Optional[int] = None,
+    ) -> None: ...
     def address(self) -> str: ...
     def shutdown(self) -> None: ...


### PR DESCRIPTION
This fixes the announced address when the manager binds to port 0. Previously we were announcing an address with port 0 which caused a connection error when restoring from checkpoint.

Test plan:

```
torchft_lighthouse --min_replicas 2 --join_timeout_ms 1000
CUDA_VISIBLE_DEVICES=0 TORCHFT_LIGHTHOUSE=http://localhost:29510 torchrun --master_port 29502 --nnodes 1 --nproc_per_node 1 --max-restarts 10 train_ddp.py
CUDA_VISIBLE_DEVICES=1 TORCHFT_LIGHTHOUSE=http://localhost:29510 torchrun --master_port 29501 --nnodes 1 --nproc_per_node 1 --max-restarts 10 train_ddp.py
```
