### PR TITLE
process_group: wait for futher_thread join before creating new one

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -609,8 +609,14 @@ class ProcessGroupBaby(ProcessGroup):
         if self._rx is not None:
             self._rx.close()
         if self._future_queue is not None:
+            # wait for the future thread to exit and then close the queue
             self._future_queue.put(_QUEUE_CLOSE)
-            assert self._future_queue is not None
+            assert self._future_thread is not None
+            self._future_thread.join(timeout=10.0)
+            # pyre-ignore[16]: optional value is checked above
+            if self._future_thread.is_alive():
+                raise RuntimeError("future thread did not exit")
+            # pyre-ignore[16]: optional value is checked above
             self._future_queue.close()
 
         ctx = mp.get_context("spawn")


### PR DESCRIPTION
This modified the configure behavior in ProcessGroupBaby so that we wait for the futher thread to be terminated before we create new ones. This fixed a race condition where futher queue might be closed while futher thread was still trying to get item from it.

Test plan:
Added test cases for reconfiguring ProcessGroupBaby and included assertions to make sure internal state is set as expected.