### PR TITLE
feat: fix security warnings in torchft

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ matplotlib
 papermill
 ipykernel
 ipython_genutils
-jinja2==3.1.4
+jinja2==3.1.5
 sphinx-autobuild


### PR DESCRIPTION
Summary:
Update jinja to address dependabot reported alerts.
1. Jinja has a sandbox breakout through malicious filename
2. Jinja has a sandbox breakout through indirect reference to format method.

Test Plan:
Test on github