### PR TITLE
lighthouse, manager: remove room support

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -50,11 +50,7 @@ message Quorum {
 }
 
 message LighthouseQuorumRequest {
-    // room_id is the specific quorum channel to use. All workers/replicas
-    // participating in the quorum must specify the same channel.
-    // Multiple channels can be active simultaneously.
-    string room_id = 1;
-    QuorumMember requester = 2;
+    QuorumMember requester = 1;
 }
 
 message LighthouseQuorumResponse {
@@ -73,13 +69,9 @@ service LighthouseService {
 }
 
 message ManagerQuorumRequest {
-    // room_id is the specific quorum channel to use. All workers/replicas
-    // participating in the quorum must specify the same channel.
-    // Multiple channels can be active simultaneously.
-    string room_id = 1;
-    int64 rank = 2;
-    int64 step = 3;
-    string checkpoint_server_addr = 4;
+    int64 rank = 1;
+    int64 step = 2;
+    string checkpoint_server_addr = 3;
 }
 
 message ManagerQuorumResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,11 +105,10 @@ impl ManagerClient {
         })
     }
 
-    #[pyo3(signature = (room_id, rank, step, checkpoint_server_addr, timeout=None))]
+    #[pyo3(signature = (rank, step, checkpoint_server_addr, timeout=None))]
     fn quorum(
         &mut self,
         py: Python<'_>,
-        room_id: String,
         rank: i64,
         step: i64,
         checkpoint_server_addr: String,
@@ -117,7 +116,6 @@ impl ManagerClient {
     ) -> Result<(i64, i64, i64, String, String, i64, Option<i64>, i64, bool), StatusError> {
         py.allow_threads(move || {
             let mut request = tonic::Request::new(ManagerQuorumRequest {
-                room_id: room_id,
                 rank: rank,
                 step: step,
                 checkpoint_server_addr: checkpoint_server_addr,

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,12 +1,9 @@
 
-{% for room in rooms %}
-<h2>Room Status: {{room.room_id}}</h2>
-
-Current quorum_id: {{room.quorum_id}} <br>
-Next quorum status: {{room.quorum_status}}
+Current quorum_id: {{quorum_id}} <br>
+Next quorum status: {{quorum_status}}
 
 <h3>Previous Quorum</h3>
-{% if let Some(prev_quorum) = room.prev_quorum %}
+{% if let Some(prev_quorum) = prev_quorum %}
 
 Previous quorum id: {{prev_quorum.quorum_id}} <br>
 Quorum age:
@@ -16,7 +13,7 @@ Quorum age:
 {% for member in prev_quorum.participants %}
 
 <div class="member
- {% if member.step != room.max_step %}recovering{% endif %}
+ {% if member.step != max_step %}recovering{% endif %}
 ">
   <b>{{ member.replica_id }}</b> <br/>
   Step: {{ member.step }} <br/>
@@ -34,8 +31,6 @@ Quorum age:
 </div>
 
 {% endif %}
-
-{% endfor %}
 
 <h2>Heartbeats</h2>
 

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -337,7 +337,6 @@ class Manager:
 
     def start_quorum(
         self,
-        room_id: str = "default",
         allow_heal: bool = True,
         timeout: Optional[timedelta] = None,
     ) -> None:
@@ -356,8 +355,6 @@ class Manager:
                 If allow_heal is set, the manager will attempt to heal either
                 synchronously before returning or asynchronously prior to any network
                 calls. All replicas must pass the same value to allow_heal.
-            room_id: (experimental) the room id to use for quorum, this allows
-                for multiple quorums to be used within the same job.
             timeout: the timeout for quorum and recovery operations, if None, the manager's timeout will be used
         """
 
@@ -374,7 +371,6 @@ class Manager:
 
         self._quorum_future = self._executor.submit(
             self._async_quorum,
-            room_id=room_id,
             allow_heal=allow_heal,
             timeout=timeout or self._timeout,
         )
@@ -400,7 +396,7 @@ class Manager:
         ), "must call start_quorum before wait_quorum"
         self._quorum_future.result()
 
-    def _async_quorum(self, room_id: str, allow_heal: bool, timeout: timedelta) -> None:
+    def _async_quorum(self, allow_heal: bool, timeout: timedelta) -> None:
         (
             quorum_id,
             replica_rank,
@@ -412,7 +408,6 @@ class Manager:
             max_world_size,
             heal,
         ) = self._client.quorum(
-            room_id=room_id,
             rank=self._rank,
             step=self._step,
             checkpoint_server_addr=self._ckpt_server.address(),

--- a/torchft/torchft.pyi
+++ b/torchft/torchft.pyi
@@ -5,7 +5,6 @@ class ManagerClient:
     def __init__(self, addr: str, timeout: timedelta) -> None: ...
     def quorum(
         self,
-        room_id: str,
         rank: int,
         step: int,
         checkpoint_server_addr: str,


### PR DESCRIPTION
This removes previously added room support in #48

This didn't work out in practice as expected and will be instead replaced with "shrink only" quorum support which is a bit easier to reason about and doesn't require absurdly long timeouts.

Test plan:

```
pytest
cargo test
```