### PR TITLE
lighthouse/quorum: avoid split brain and add shrink_only support

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -41,6 +41,7 @@ message QuorumMember {
     string store_address = 3;
     int64 step = 4;
     uint64 world_size = 5;
+    bool shrink_only = 6;
 }
 
 message Quorum {
@@ -72,6 +73,7 @@ message ManagerQuorumRequest {
     int64 rank = 1;
     int64 step = 2;
     string checkpoint_server_addr = 3;
+    bool shrink_only = 4;
 }
 
 message ManagerQuorumResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,13 +105,14 @@ impl ManagerClient {
         })
     }
 
-    #[pyo3(signature = (rank, step, checkpoint_server_addr, timeout=None))]
+    #[pyo3(signature = (rank, step, checkpoint_server_addr, shrink_only, timeout=None))]
     fn quorum(
         &mut self,
         py: Python<'_>,
         rank: i64,
         step: i64,
         checkpoint_server_addr: String,
+        shrink_only: bool,
         timeout: Option<Duration>,
     ) -> Result<(i64, i64, i64, String, String, i64, Option<i64>, i64, bool), StatusError> {
         py.allow_threads(move || {
@@ -119,6 +120,7 @@ impl ManagerClient {
                 rank: rank,
                 step: step,
                 checkpoint_server_addr: checkpoint_server_addr,
+                shrink_only: shrink_only,
             });
             // This notifies the server about the timeout but doesn't affect the
             // endpoint timeout which we set on client creation.

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -58,40 +58,6 @@ class TestLighthouse(TestCase):
             join_timeout_ms=400,
         )
 
-        # Create a manager that tries to join
-        try:
-            store = dist.TCPStore(
-                host_name="localhost",
-                port=0,
-                is_master=True,
-                wait_for_workers=False,
-            )
-            pg = ProcessGroupGloo()
-            manager = Manager(
-                pg=pg,
-                min_replica_size=1,
-                load_state_dict=lambda x: None,
-                state_dict=lambda: None,
-                replica_id=f"lighthouse_test",
-                store_addr="localhost",
-                store_port=store.port,
-                rank=0,
-                world_size=1,
-                use_async_quorum=False,
-                lighthouse_addr=lighthouse.address(),
-            )
-
-            start_time = time.time()
-            manager.start_quorum()
-            time_taken = time.time() - start_time
-            assert time_taken > 0.4, f"Time taken to join: {time_taken} < 0.4s"
-
-        finally:
-            # Cleanup
-            lighthouse.shutdown()
-            if "manager" in locals():
-                manager.shutdown()
-
     def test_heartbeat_timeout_ms_sanity(self) -> None:
         lighthouse = Lighthouse(
             bind="[::]:0",

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -338,6 +338,7 @@ class Manager:
     def start_quorum(
         self,
         allow_heal: bool = True,
+        shrink_only: bool = False,
         timeout: Optional[timedelta] = None,
     ) -> None:
         """
@@ -372,6 +373,7 @@ class Manager:
         self._quorum_future = self._executor.submit(
             self._async_quorum,
             allow_heal=allow_heal,
+            shrink_only=shrink_only,
             timeout=timeout or self._timeout,
         )
         if not self._use_async_quorum:
@@ -396,7 +398,9 @@ class Manager:
         ), "must call start_quorum before wait_quorum"
         self._quorum_future.result()
 
-    def _async_quorum(self, allow_heal: bool, timeout: timedelta) -> None:
+    def _async_quorum(
+        self, allow_heal: bool, shrink_only: bool, timeout: timedelta
+    ) -> None:
         (
             quorum_id,
             replica_rank,
@@ -411,6 +415,7 @@ class Manager:
             rank=self._rank,
             step=self._step,
             checkpoint_server_addr=self._ckpt_server.address(),
+            shrink_only=shrink_only,
             timeout=timeout,
         )
 

--- a/torchft/torchft.pyi
+++ b/torchft/torchft.pyi
@@ -8,6 +8,7 @@ class ManagerClient:
         rank: int,
         step: int,
         checkpoint_server_addr: str,
+        shrink_only: bool,
         timeout: Optional[timedelta] = None,
     ) -> Tuple[int, int, int, str, str, int, Optional[int], int, bool]: ...
     def checkpoint_address(


### PR DESCRIPTION
This modifies the quorum behavior with a few major changes:

1. the quorum won't complete unless at least half of the heartbeating replicas join the quorum (this is to avoid split brain conditions) except in fast quorum cases when we're growing the quorum
  Rational: in scale up scenarios we could end up in split brain cases where min_replicas=2, but total replicas = 10 and we end up flip/flopping the quorum with effectively two separate jobs
2. the join_timeout now only applies if there's a heartbeating replica which hasn't joined the quorum 
  Rational: since heartbeating starts when manager starts (often before model init), there's not much use in waiting out the full time since we probably won't have any workers join and we have at least min_replicas
  (TODO: should we remove fast quorum as we can now complete quorum without waiting for the entire join timeout?)
3. added `shrink_only` support which will only allow workers to drop out but no new ones to join
  Rational: this is intended to support long step times such as needed in LocalSGD

Test plan:

Updated/added quorum test cases and added asserts on the explainations

```
cargo test
```