### PR TITLE
overhaul timeouts for Lighthouse, Manager, checkpoint server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4.22"
 prost = "0.13.3"
 prost-types = "0.13.3"
 pyo3 = {version="0.22.3", features = ["extension-module"]}
+rand = "0.8.5"
 slog = "2.7.0"
 slog-stdlog = "4.1.1"
 stderrlog = "0.6.0"

--- a/src/lighthouse.rs
+++ b/src/lighthouse.rs
@@ -543,15 +543,13 @@ mod tests {
     use super::*;
     use std::ops::Sub;
 
-    use tonic::transport::{Channel, Endpoint};
+    use tonic::transport::Channel;
 
+    use crate::net::connect;
     use crate::torchftpb::lighthouse_service_client::LighthouseServiceClient;
 
     async fn lighthouse_client_new(addr: String) -> Result<LighthouseServiceClient<Channel>> {
-        let conn = Endpoint::new(addr)?
-            .connect_timeout(Duration::from_secs(10))
-            .connect()
-            .await?;
+        let conn = connect(addr, Duration::from_secs(10)).await?;
         Ok(LighthouseServiceClient::new(conn))
     }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use tonic::transport::{Channel, Endpoint};
+
+use crate::retry::{retry_backoff, ExponentialBackoff};
+
+pub async fn connect_once(addr: String, connect_timeout: Duration) -> Result<Channel> {
+    let conn = Endpoint::new(addr)?
+        .connect_timeout(connect_timeout)
+        // Enable HTTP2 keep alives
+        .http2_keep_alive_interval(Duration::from_secs(60))
+        // Time taken for server to respond. 20s is default for GRPC.
+        .keep_alive_timeout(Duration::from_secs(20))
+        // Enable alive for idle connections.
+        .keep_alive_while_idle(true)
+        .connect()
+        .await?;
+    Ok(conn)
+}
+
+pub async fn connect(addr: String, connect_timeout: Duration) -> Result<Channel> {
+    retry_backoff(
+        ExponentialBackoff {
+            initial_backoff: Duration::from_millis(100),
+            max_backoff: Duration::from_secs(10),
+            timeout: connect_timeout,
+            factor: 1.5,
+            max_jitter: Duration::from_millis(100),
+        },
+        || Box::pin(connect_once(addr.clone(), connect_timeout)),
+    )
+    .await
+}

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+
+pub struct ExponentialBackoff {
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+    pub timeout: Duration,
+    pub factor: f64,
+    pub max_jitter: Duration,
+}
+
+pub async fn retry_backoff<F, R>(policy: ExponentialBackoff, f: F) -> Result<R>
+where
+    F: Fn() -> Pin<Box<dyn Future<Output = Result<R>> + Send>>,
+    R: Send,
+{
+    assert!(policy.initial_backoff > Duration::from_millis(0));
+    assert!(policy.factor > 1.0);
+    let mut backoff = policy.initial_backoff;
+
+    let deadline = Instant::now() + policy.timeout;
+
+    loop {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if Instant::now() > deadline {
+                    return Err(e);
+                }
+                let jitter = policy.max_jitter.mul_f64(rand::random::<f64>());
+                tokio::time::sleep(backoff + jitter).await;
+                backoff = backoff.mul_f64(policy.factor);
+                if backoff > policy.max_backoff {
+                    backoff = policy.max_backoff;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    #[tokio::test]
+    async fn test_retry_backoff() -> Result<()> {
+        let count = Arc::new(Mutex::new(0));
+        let result = retry_backoff(
+            ExponentialBackoff {
+                initial_backoff: Duration::from_millis(1),
+                max_backoff: Duration::from_millis(100),
+                timeout: Duration::from_secs(1000),
+                factor: 2.0,
+                max_jitter: Duration::from_millis(1),
+            },
+            || {
+                let current_count = {
+                    let mut count = count.lock().unwrap();
+                    *count += 1;
+                    *count
+                };
+
+                Box::pin(async move {
+                    if current_count < 3 {
+                        Err(anyhow::anyhow!("test"))
+                    } else {
+                        Ok(1234)
+                    }
+                })
+            },
+        )
+        .await?;
+        assert!(result == 1234);
+        let count = *count.lock().unwrap();
+        assert!(count == 3, "count: {}", count);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_retry_backoff_timeout() -> Result<()> {
+        let result: Result<()> = retry_backoff(
+            ExponentialBackoff {
+                initial_backoff: Duration::from_millis(1),
+                max_backoff: Duration::from_millis(100),
+                timeout: Duration::from_millis(1),
+                factor: 2.0,
+                max_jitter: Duration::from_millis(1),
+            },
+            || Box::pin(async { Err(anyhow::anyhow!("test")) }),
+        )
+        .await;
+
+        assert!(result.is_err());
+        Ok(())
+    }
+}

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,0 +1,87 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use tonic::metadata::{Ascii, MetadataMap, MetadataValue};
+
+const GRPC_TIMEOUT_HEADER: &str = "grpc-timeout";
+const SECONDS_IN_HOUR: u64 = 60 * 60;
+const SECONDS_IN_MINUTE: u64 = 60;
+
+/// Tries to parse the `grpc-timeout` header if it is present. If we fail to parse, returns
+/// the value we attempted to parse.
+///
+/// Follows the [gRPC over HTTP2 spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).
+///
+/// From https://github.com/hyperium/tonic/blob/79a06cc8067818ec53bae76ab717063683bb0acb/tonic/src/transport/service/grpc_timeout.rs#L106
+/// Copyright (c) 2020 Lucio Franco MIT License
+/// https://github.com/hyperium/tonic/blob/master/LICENSE
+pub fn try_parse_grpc_timeout(
+    headers: &MetadataMap,
+) -> Result<Option<Duration>, &MetadataValue<Ascii>> {
+    let Some(val) = headers.get(GRPC_TIMEOUT_HEADER) else {
+        return Ok(None);
+    };
+
+    let (timeout_value, timeout_unit) = val
+        .to_str()
+        .map_err(|_| val)
+        .and_then(|s| if s.is_empty() { Err(val) } else { Ok(s) })?
+        // `MetadataValue::to_str` only returns `Ok` if the header contains ASCII so this
+        // `split_at` will never panic from trying to split in the middle of a character.
+        // See https://docs.rs/http/0.2.4/http/header/struct.MetadataValue.html#method.to_str
+        //
+        // `len - 1` also wont panic since we just checked `s.is_empty`.
+        .split_at(val.len() - 1);
+
+    // gRPC spec specifies `TimeoutValue` will be at most 8 digits
+    // Caping this at 8 digits also prevents integer overflow from ever occurring
+    if timeout_value.len() > 8 {
+        return Err(val);
+    }
+
+    let timeout_value: u64 = timeout_value.parse().map_err(|_| val)?;
+
+    let duration = match timeout_unit {
+        // Hours
+        "H" => Duration::from_secs(timeout_value * SECONDS_IN_HOUR),
+        // Minutes
+        "M" => Duration::from_secs(timeout_value * SECONDS_IN_MINUTE),
+        // Seconds
+        "S" => Duration::from_secs(timeout_value),
+        // Milliseconds
+        "m" => Duration::from_millis(timeout_value),
+        // Microseconds
+        "u" => Duration::from_micros(timeout_value),
+        // Nanoseconds
+        "n" => Duration::from_nanos(timeout_value),
+        _ => return Err(val),
+    };
+
+    Ok(Some(duration))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parsing() {
+        fn map(val: &str) -> MetadataMap {
+            let mut map = MetadataMap::new();
+            map.insert(GRPC_TIMEOUT_HEADER, val.parse().unwrap());
+            map
+        }
+
+        assert!(try_parse_grpc_timeout(&map("3H")).unwrap() == Some(Duration::from_secs(3 * 3600)));
+        assert!(try_parse_grpc_timeout(&map("3M")).unwrap() == Some(Duration::from_secs(3 * 60)));
+        assert!(try_parse_grpc_timeout(&map("3S")).unwrap() == Some(Duration::from_secs(3)));
+        assert!(try_parse_grpc_timeout(&map("3m")).unwrap() == Some(Duration::from_millis(3)));
+        assert!(try_parse_grpc_timeout(&map("3u")).unwrap() == Some(Duration::from_micros(3)));
+        assert!(try_parse_grpc_timeout(&map("3n")).unwrap() == Some(Duration::from_nanos(3)));
+
+        assert!(try_parse_grpc_timeout(&MetadataMap::new())
+            .unwrap()
+            .is_none());
+        assert!(try_parse_grpc_timeout(&map("")).is_err());
+    }
+}

--- a/torchft/checkpointing_test.py
+++ b/torchft/checkpointing_test.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import urllib.error
+from datetime import timedelta
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -16,20 +17,27 @@ class TestCheckpointing(TestCase):
         expected = {"state": "dict"}
         state_dict_fn = MagicMock()
         state_dict_fn.return_value = expected
-        server = CheckpointServer(state_dict=state_dict_fn)
+        server = CheckpointServer(
+            state_dict=state_dict_fn,
+            timeout=timedelta(seconds=10),
+        )
 
         server.disallow_checkpoint()
         server.allow_checkpoint(1234)
 
         addr = server.address()
 
-        out = CheckpointServer.load_from_address(addr)
+        out = CheckpointServer.load_from_address(addr, timeout=timedelta(seconds=10))
         self.assertEqual(out, expected)
+
+        # test timeout
+        with self.assertRaisesRegex(urllib.error.URLError, r"urlopen error"):
+            CheckpointServer.load_from_address(addr, timeout=timedelta(seconds=0.0))
 
         # test mismatch case
         server.allow_checkpoint(2345)
 
         with self.assertRaisesRegex(urllib.error.HTTPError, r"Error 400"):
-            CheckpointServer.load_from_address(addr)
+            CheckpointServer.load_from_address(addr, timeout=timedelta(seconds=10))
 
         server.shutdown()

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -133,7 +133,9 @@ class ProcessGroupTest(TestCase):
 
         store_addr = f"localhost:{store.port}/prefix"
         pg = ProcessGroupGloo(timeout=timedelta(seconds=0.01))
-        with self.assertRaisesRegex(RuntimeError, "timeout after 10ms"):
+        with self.assertRaisesRegex(
+            RuntimeError, "(timeout after 10ms|Socket Timeout)"
+        ):
             pg.configure(store_addr, 0, 2)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of argument

--- a/torchft/torchft.pyi
+++ b/torchft/torchft.pyi
@@ -2,24 +2,22 @@ from datetime import timedelta
 from typing import Optional, Tuple
 
 class ManagerClient:
-    def __init__(self, addr: str, timeout: timedelta) -> None: ...
+    def __init__(self, addr: str, connect_timeout: timedelta) -> None: ...
     def quorum(
         self,
         rank: int,
         step: int,
         checkpoint_server_addr: str,
         shrink_only: bool,
-        timeout: Optional[timedelta] = None,
+        timeout: timedelta,
     ) -> Tuple[int, int, int, str, str, int, Optional[int], int, bool]: ...
-    def checkpoint_address(
-        self, rank: int, timeout: Optional[timedelta] = None
-    ) -> str: ...
+    def checkpoint_address(self, rank: int, timeout: timedelta) -> str: ...
     def should_commit(
         self,
         rank: int,
         step: int,
         should_commit: bool,
-        timeout: Optional[timedelta] = None,
+        timeout: timedelta,
     ) -> bool: ...
 
 class Manager:
@@ -32,6 +30,7 @@ class Manager:
         store_addr: str,
         world_size: int,
         heartbeat_interval: timedelta,
+        connect_timeout: timedelta,
     ) -> None: ...
     def address(self) -> str: ...
     def shutdown(self) -> None: ...


### PR DESCRIPTION
This overhauls the timeouts for all network operations to allow for long quorum timeouts in a safer way.

Notable changes:

* removes timeout from the Endpoint/Channel/Client in favor of using keep alives + server based timeouts
* adds timeouts to CheckpointServer
* requires timeouts to be passed for all Rust operations
* adds a new `quorum_timeout` field to Manager py so you can have a much longer quorum timeout

Test plan:

```
pytest
cargo test
```