### PR TITLE
lib: fix Already borrowed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ impl ManagerClient {
     }
 
     fn quorum(
-        &mut self,
+        &self,
         py: Python<'_>,
         rank: i64,
         step: i64,
@@ -129,7 +129,7 @@ impl ManagerClient {
             // keep alives to detect server health.
             request.set_timeout(timeout);
 
-            let response = self.runtime.block_on(self.client.quorum(request))?;
+            let response = self.runtime.block_on(self.client.clone().quorum(request))?;
             let resp = response.into_inner();
             Ok((
                 resp.quorum_id,
@@ -146,7 +146,7 @@ impl ManagerClient {
     }
 
     fn checkpoint_address(
-        &mut self,
+        &self,
         py: Python<'_>,
         rank: i64,
         timeout: Duration,
@@ -160,14 +160,14 @@ impl ManagerClient {
 
             let response = self
                 .runtime
-                .block_on(self.client.checkpoint_address(request))?;
+                .block_on(self.client.clone().checkpoint_address(request))?;
             let resp = response.into_inner();
             Ok(resp.checkpoint_server_address)
         })
     }
 
     fn should_commit(
-        &mut self,
+        &self,
         py: Python<'_>,
         rank: i64,
         step: i64,
@@ -185,7 +185,9 @@ impl ManagerClient {
             // endpoint timeout which we set on client creation.
             request.set_timeout(timeout);
 
-            let response = self.runtime.block_on(self.client.should_commit(request))?;
+            let response = self
+                .runtime
+                .block_on(self.client.clone().should_commit(request))?;
             let resp = response.into_inner();
             Ok(resp.should_commit)
         })


### PR DESCRIPTION
This fixes errors from Rust when calling the manager from multiple threads.

```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/home/mreso/torchft/train_fsdp.py", line 176, in <module>
[rank1]:     main()
[rank1]:   File "/home/mreso/torchft/train_fsdp.py", line 169, in main
[rank1]:     optimizer.step()
[rank1]:   File "/home/mreso/torchft/torchft/optim.py", line 53, in step
[rank1]:     if self.manager.should_commit():
[rank1]:   File "/home/mreso/torchft/torchft/manager.py", line 556, in should_commit
[rank1]:     should_commit = self._client.should_commit(
[rank1]: RuntimeError: Already borrowed
```

We have the Manager receiver type set as `&mut self` when it really doesn't need to be. We instead do a lightweight clone of the client when making network calls.

See https://github.com/PyO3/pyo3/discussions/2465 for more details

Test plan:

```
pytest
cargo test
```