### PR TITLE
checkpointing: use CheckpointTransport abstraction

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -72,30 +72,32 @@ service LighthouseService {
 message ManagerQuorumRequest {
     int64 rank = 1;
     int64 step = 2;
-    string checkpoint_server_addr = 3;
+    string checkpoint_metadata = 3;
     bool shrink_only = 4;
 }
 
 message ManagerQuorumResponse {
     int64 quorum_id = 1;
-    string address = 2;
-    string store_address = 3;
+    string recover_src_manager_address = 2;
+    optional int64 recover_src_rank = 3;
+    repeated int64 recover_dst_ranks = 4;
+    string store_address = 5;
     // These are information for the replicas which are at the max step.
-    int64 max_step = 4;
-    optional int64 max_rank = 5;
-    int64 max_world_size = 6;
+    int64 max_step = 6;
+    optional int64 max_rank = 7;
+    int64 max_world_size = 8;
     // These are information for all replicas including behind replicas.
-    int64 replica_rank = 7;
-    int64 replica_world_size = 8;
-    bool heal = 9;
+    int64 replica_rank = 9;
+    int64 replica_world_size = 10;
+    bool heal = 11;
 }
 
-message CheckpointAddressRequest {
+message CheckpointMetadataRequest {
     int64 rank = 1;
 }
 
-message CheckpointAddressResponse {
-    string checkpoint_server_address = 1;
+message CheckpointMetadataResponse {
+    string checkpoint_metadata = 1;
 }
 
 message ShouldCommitRequest {
@@ -114,7 +116,7 @@ message KillResponse {}
 
 service ManagerService {
     rpc Quorum (ManagerQuorumRequest) returns (ManagerQuorumResponse);
-    rpc CheckpointAddress(CheckpointAddressRequest) returns (CheckpointAddressResponse);
+    rpc CheckpointMetadata(CheckpointMetadataRequest) returns (CheckpointMetadataResponse);
     rpc ShouldCommit(ShouldCommitRequest) returns (ShouldCommitResponse);
     rpc Kill(KillRequest) returns (KillResponse);
 }

--- a/torchft/manager_integ_test.py
+++ b/torchft/manager_integ_test.py
@@ -159,7 +159,7 @@ def ddp_train_loop(
             # pyre-fixme[6]: Incompatible parameter type
             **runner.manager_args,
         )
-        stack.callback(manager.shutdown)
+        stack.callback(lambda: manager.shutdown(wait=False))
 
         m: nn.Module = DistributedDataParallel(manager, MyModel())
         optimizer: optim.Optimizer = OptimizerWrapper(
@@ -223,7 +223,7 @@ def local_sgd_train_loop(
             # pyre-fixme[6]: Incompatible parameter type
             **runner.manager_args,
         )
-        stack.callback(manager.shutdown)
+        stack.callback(lambda: manager.shutdown(wait=False))
 
         m: nn.Module = MyModel()
         optimizer: optim.Optimizer = optim.Adam(m.parameters())
@@ -460,7 +460,7 @@ class ManagerIntegTest(TestCase):
                 port=19530,
                 use_async_quorum=False,
             )
-            stack.callback(manager.shutdown)
+            stack.callback(lambda: manager.shutdown(wait=False))
 
             with self.assertElapsedLessThan(1.0):
                 with self.assertRaisesRegex(

--- a/torchft/torchft.pyi
+++ b/torchft/torchft.pyi
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Optional, Tuple
+from typing import List, Optional
 
 class ManagerClient:
     def __init__(self, addr: str, connect_timeout: timedelta) -> None: ...
@@ -7,11 +7,11 @@ class ManagerClient:
         self,
         rank: int,
         step: int,
-        checkpoint_server_addr: str,
+        checkpoint_metadata: str,
         shrink_only: bool,
         timeout: timedelta,
-    ) -> Tuple[int, int, int, str, str, int, Optional[int], int, bool]: ...
-    def checkpoint_address(self, rank: int, timeout: timedelta) -> str: ...
+    ) -> QuorumResult: ...
+    def checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
     def should_commit(
         self,
         rank: int,
@@ -19,6 +19,19 @@ class ManagerClient:
         should_commit: bool,
         timeout: timedelta,
     ) -> bool: ...
+
+class QuorumResult:
+    quorum_id: int
+    replica_rank: int
+    replica_world_size: int
+    recover_src_manager_address: str
+    recover_src_rank: Optional[int]
+    recover_dst_ranks: List[int]
+    store_address: str
+    max_step: int
+    max_rank: Optional[int]
+    max_world_size: int
+    heal: bool
 
 class Manager:
     def __init__(


### PR DESCRIPTION
This is a major refactoring of the live checkpointing code.

New behavior:

* Uses round robin recovery rather than all workers recovering from the primary (new logic in compute_quorum_result)

Key refactors:

* made a new generalized `CheckpointTransport` which `CheckpointServer` implements. This abstraction is designed to be symmetric for recovery strategies that require both sender and receiver to be aware of the communication. This will allow for recovering via ProcessGroups/NCCL which can be significantly faster.
* Made `ManagerClient.quorum` return a `QuorumResult` struct rather than a named tuple
* Renamed `checkpoint_address` to `checkpoint_metadata` as not all transports will be using an address
* Refactored recovery logic into `compute_quorum_result` method and added better unit tests for it
* Added checkpoint_metadata tests (there were no checkpoint_address tests previously)

Test plan:

```
pytest
cargo test
```
