### PR TITLE
process_group/ManagedProcessGroup: ensure quorum and PG is configured

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -19,7 +19,6 @@ runtime users need to take care to not assume a static rank or world size.
 import logging
 import queue
 import threading
-from abc import ABC
 from datetime import timedelta
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 
@@ -507,6 +506,10 @@ class ManagedProcessGroup(ProcessGroupWrapper):
         self._manager = manager
 
     def allreduce(self, tensors: List[torch.Tensor], opts: object) -> Work:
+        # Ensure we have a valid quorum and are configured before trying to do
+        # any work.
+        self._manager.wait_quorum()
+
         if self._manager.errored() is not None:
             return _DummyWork(tensors)
 

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -368,6 +368,7 @@ class ProcessGroupTest(TestCase):
 
         self.assertEqual(manager.report_error.call_count, 0)
         self.assertEqual(manager.wrap_future.call_count, 1)
+        self.assertEqual(manager.wait_quorum.call_count, 1)
 
 
 class DeviceMeshTest(TestCase):


### PR DESCRIPTION
Without this we will start running operations before the process group has been reconfigured/initialized. This can result in crashes, timeouts and deadlocking

When using Manager `allreduce` this already is the behavior so we just need to make sure we match the behavior for ManagedProcessGroup.

This was observed in https://github.com/pytorch/torchtitan/pull/806

Test plan:

```
pytest
lintrunner -a
```

Testing w/ https://github.com/pytorch/torchtitan/pull/806