### PR TITLE
coordination: expose new low level torchft coordination API

### DIFF
--- a/docs/source/coordination.rst
+++ b/docs/source/coordination.rst
@@ -1,0 +1,4 @@
+.. automodule:: torchft.coordination
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ the entire training job.
     data
     checkpointing
     parameter_server
+    coordination
 
 
 License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+module-name = "torchft._torchft"
 
 [project.scripts]
 torchft_lighthouse = "torchft.torchft:lighthouse_main"

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 class ManagerClient:
     def __init__(self, addr: str, connect_timeout: timedelta) -> None: ...
-    def quorum(
+    def _quorum(
         self,
         rank: int,
         step: int,
@@ -11,7 +11,7 @@ class ManagerClient:
         shrink_only: bool,
         timeout: timedelta,
     ) -> QuorumResult: ...
-    def checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
+    def _checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
     def should_commit(
         self,
         rank: int,
@@ -33,7 +33,7 @@ class QuorumResult:
     max_world_size: int
     heal: bool
 
-class Manager:
+class ManagerServer:
     def __init__(
         self,
         replica_id: str,
@@ -48,7 +48,7 @@ class Manager:
     def address(self) -> str: ...
     def shutdown(self) -> None: ...
 
-class Lighthouse:
+class LighthouseServer:
     def __init__(
         self,
         bind: str,

--- a/torchft/coordination.py
+++ b/torchft/coordination.py
@@ -1,0 +1,23 @@
+"""
+Coordination (Low Level API)
+============================
+
+.. warning::
+    As torchft is still in development, the APIs in this module are subject to change.
+
+This module exposes low level coordination APIs to allow you to build your own 
+custom fault tolerance algorithms on top of torchft.
+
+If you're looking for a more complete solution, please use the other modules in
+torchft.
+
+This provides direct access to the Lighthouse and Manager servers and clients.
+"""
+
+from torchft._torchft import LighthouseServer, ManagerClient, ManagerServer
+
+__all__ = [
+    "LighthouseServer",
+    "ManagerServer",
+    "ManagerClient",
+]

--- a/torchft/coordination_test.py
+++ b/torchft/coordination_test.py
@@ -1,0 +1,19 @@
+import inspect
+from unittest import TestCase
+
+from torchft.coordination import LighthouseServer, ManagerClient, ManagerServer
+
+
+class TestCoordination(TestCase):
+    def test_coordination_docs(self) -> None:
+        classes = [
+            ManagerClient,
+            ManagerServer,
+            LighthouseServer,
+        ]
+        for cls in classes:
+            self.assertIn("Args:", str(cls.__doc__), cls)
+            for name, method in inspect.getmembers(cls, predicate=inspect.ismethod):
+                if name.startswith("_"):
+                    continue
+                self.assertIn("Args:", str(cls.__doc__), cls)

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 import torch.distributed as dist
 
 from torchft import Manager, ProcessGroupGloo
-from torchft.torchft import Lighthouse
+from torchft._torchft import LighthouseServer
 
 
 class TestLighthouse(TestCase):
@@ -12,7 +12,7 @@ class TestLighthouse(TestCase):
         """Test that join_timeout_ms affects joining behavior"""
         # To test, we create a lighthouse with 100ms and 400ms join timeouts
         # and measure the time taken to validate the quorum.
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=1,
             join_timeout_ms=100,
@@ -52,14 +52,14 @@ class TestLighthouse(TestCase):
             if "manager" in locals():
                 manager.shutdown()
 
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=1,
             join_timeout_ms=400,
         )
 
     def test_heartbeat_timeout_ms_sanity(self) -> None:
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=1,
             heartbeat_timeout_ms=100,

--- a/torchft/local_sgd_integ_test.py
+++ b/torchft/local_sgd_integ_test.py
@@ -8,11 +8,11 @@ from unittest import TestCase
 import torch
 from torch import nn, optim
 
+from torchft._torchft import LighthouseServer
 from torchft.local_sgd import DiLoCo, LocalSGD
 from torchft.manager import Manager
 from torchft.manager_integ_test import FailureInjector, MyModel, Runner
 from torchft.process_group import ProcessGroupGloo
-from torchft.torchft import Lighthouse
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -166,7 +166,7 @@ def diloco_train_loop(
 
 class ManagerIntegTest(TestCase):
     def test_local_sgd_recovery(self) -> None:
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=2,
         )
@@ -214,7 +214,7 @@ class ManagerIntegTest(TestCase):
         self.assertEqual(failure_injectors[1].count, 1)
 
     def test_diloco_healthy(self) -> None:
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=2,
         )
@@ -258,7 +258,7 @@ class ManagerIntegTest(TestCase):
                 )
 
     def test_diloco_recovery(self) -> None:
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=2,
         )

--- a/torchft/manager_integ_test.py
+++ b/torchft/manager_integ_test.py
@@ -14,12 +14,12 @@ import torch.distributed as dist
 from parameterized import parameterized
 from torch import nn, optim
 
+from torchft._torchft import LighthouseServer
 from torchft.ddp import DistributedDataParallel
 from torchft.local_sgd import DiLoCo, LocalSGD
 from torchft.manager import Manager
 from torchft.optim import OptimizerWrapper
 from torchft.process_group import ProcessGroupGloo
-from torchft.torchft import Lighthouse
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -201,7 +201,7 @@ class ManagerIntegTest(TestCase):
         self.assertLess(elapsed, timeout, msg)
 
     def test_ddp_healthy(self) -> None:
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=2,
         )
@@ -242,7 +242,7 @@ class ManagerIntegTest(TestCase):
         ]
     )
     def test_ddp_recovery(self, name: str, use_async_quorum: bool) -> None:
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=2,
         )
@@ -282,7 +282,7 @@ class ManagerIntegTest(TestCase):
         self.assertEqual(failure_injectors[1].count, 1)
 
     def test_ddp_recovery_multi_rank(self) -> None:
-        lighthouse = Lighthouse(
+        lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=2,
         )
@@ -324,7 +324,7 @@ class ManagerIntegTest(TestCase):
 
     def test_quorum_timeout(self) -> None:
         with ExitStack() as stack:
-            lighthouse = Lighthouse(
+            lighthouse = LighthouseServer(
                 bind="[::]:0",
                 min_replicas=2,
             )

--- a/torchft/manager_test.py
+++ b/torchft/manager_test.py
@@ -13,9 +13,9 @@ from unittest.mock import MagicMock, create_autospec, patch
 import torch
 from torch.distributed import TCPStore
 
+from torchft._torchft import QuorumResult
 from torchft.manager import MANAGER_ADDR_KEY, REPLICA_ID_KEY, Manager, WorldSizeMode
 from torchft.process_group import ProcessGroup, _DummyWork
-from torchft.torchft import QuorumResult
 
 
 def mock_should_commit(
@@ -143,7 +143,7 @@ class TestManager(TestCase):
         quorum.max_world_size = 2
         quorum.heal = False
 
-        client_mock().quorum.return_value = quorum
+        client_mock()._quorum.return_value = quorum
 
         self.assertEqual(manager._quorum_id, -1)
         self.assertEqual(manager.current_step(), 0)
@@ -180,7 +180,7 @@ class TestManager(TestCase):
         quorum.max_world_size = 2
         quorum.heal = True
 
-        client_mock().quorum.return_value = quorum
+        client_mock()._quorum.return_value = quorum
 
         # forcible increment checkpoint server to compute correct address
         manager._checkpoint_transport.send_checkpoint(
@@ -189,7 +189,7 @@ class TestManager(TestCase):
             state_dict=manager._manager_state_dict(),
             timeout=timedelta(seconds=10),
         )
-        client_mock().checkpoint_metadata.return_value = (
+        client_mock()._checkpoint_metadata.return_value = (
             manager._checkpoint_transport.metadata()
         )
 
@@ -234,7 +234,7 @@ class TestManager(TestCase):
         quorum.max_world_size = 1
         quorum.heal = True
 
-        client_mock().quorum.return_value = quorum
+        client_mock()._quorum.return_value = quorum
 
         # forcible increment checkpoint server to compute correct address
         manager._checkpoint_transport.send_checkpoint(
@@ -243,7 +243,7 @@ class TestManager(TestCase):
             state_dict=manager._manager_state_dict(),
             timeout=timedelta(seconds=10),
         )
-        client_mock().checkpoint_metadata.return_value = (
+        client_mock()._checkpoint_metadata.return_value = (
             manager._checkpoint_transport.metadata()
         )
 
@@ -296,7 +296,7 @@ class TestManager(TestCase):
         quorum.max_world_size = 1
         quorum.heal = True
 
-        client_mock().quorum.return_value = quorum
+        client_mock()._quorum.return_value = quorum
 
         # forceable increment checkpoint server to compute correct address
         manager._checkpoint_transport.send_checkpoint(
@@ -305,7 +305,7 @@ class TestManager(TestCase):
             state_dict=manager._manager_state_dict(),
             timeout=timedelta(seconds=10),
         )
-        client_mock().checkpoint_metadata.return_value = (
+        client_mock()._checkpoint_metadata.return_value = (
             manager._checkpoint_transport.metadata()
         )
 
@@ -355,7 +355,7 @@ class TestManager(TestCase):
         quorum.max_world_size = 2
         quorum.heal = False
 
-        client_mock().quorum.return_value = quorum
+        client_mock()._quorum.return_value = quorum
 
         self.assertEqual(manager._quorum_id, -1)
         self.assertEqual(manager.current_step(), 0)
@@ -429,7 +429,7 @@ class TestManager(TestCase):
             quorum.max_world_size = 3
             quorum.heal = False
 
-            client_mock().quorum.return_value = quorum
+            client_mock()._quorum.return_value = quorum
 
             self.assertEqual(manager._quorum_id, -1)
             self.assertEqual(manager.current_step(), 0)
@@ -463,7 +463,7 @@ class TestManager(TestCase):
         quorum.max_rank = None
         quorum.max_world_size = 2
         quorum.heal = True
-        client_mock().quorum.return_value = quorum
+        client_mock()._quorum.return_value = quorum
 
         self.assertEqual(manager._quorum_id, -1)
         self.assertEqual(manager.current_step(), 0)
@@ -567,11 +567,11 @@ class TestManager(TestCase):
         quorum.max_world_size = 2
         quorum.heal = False
 
-        client_mock().quorum.return_value = quorum
+        client_mock()._quorum.return_value = quorum
 
         manager.start_quorum(timeout=timedelta(seconds=12))
         self.assertEqual(
-            client_mock().quorum.call_args.kwargs["timeout"], timedelta(seconds=12)
+            client_mock()._quorum.call_args.kwargs["timeout"], timedelta(seconds=12)
         )
 
         self.assertTrue(manager.should_commit(timeout=timedelta(seconds=23)))


### PR DESCRIPTION
This exposes LighthouseServer, ManagerServer and ManagerClient so power users can directly call them to implement custom fault tolerance strategies.

It also renames some modules (`_torchft` for Rust lib) and methods to indicate which ones are private and subject to change.

This _does not_ expose a quorum algorithm currently. The plan is to add a new "simple quorum" interface that allows for custom data to be passed between members instead of the data required by the Manager.

We may also want to expose a pluggable quorum algorithm that can be passed into LighthouseServer to customize that as well.

Test plan:

```
cd docs && make livehtml
pytest
cargo test
```

![localhost_8001_coordination html(Surface Pro 7)](https://github.com/user-attachments/assets/7ab2d345-9420-4b99-85bd-f909aa8166a7)
