### PR TITLE
Fix ManagedDeviceMesh composability issues

### DIFF
--- a/torchft/device_mesh_test.py
+++ b/torchft/device_mesh_test.py
@@ -15,7 +15,11 @@ import torch
 import torch.distributed as dist
 
 from torchft.manager import Manager
-from torchft.process_group import ManagedProcessGroup, ft_init_device_mesh
+from torchft.process_group import (
+    ManagedProcessGroup,
+    ProcessGroupGloo,
+    ft_init_device_mesh,
+)
 
 
 class DeviceMeshTest(TestCase):
@@ -29,6 +33,7 @@ class DeviceMeshTest(TestCase):
         testcase = TestCase()
 
         manager = Mock(spec=Manager)
+        manager._pg = ProcessGroupGloo()
         # Even though we only have 4 workers, we can still initialize (2, 4) mesh.
         # That's because the replicate group is NOT phystically created in the
         # real mesh but is virtually added to the mesh via ManagedDeviceMesh.

--- a/torchft/device_mesh_test.py
+++ b/torchft/device_mesh_test.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import io
+import os
+from concurrent.futures import ProcessPoolExecutor
+from typing import cast
+from unittest import TestCase
+from unittest.mock import Mock
+
+import torch
+import torch.distributed as dist
+
+from torchft.manager import Manager
+from torchft.process_group import ManagedProcessGroup, ft_init_device_mesh
+
+
+class DeviceMeshTest(TestCase):
+    @staticmethod
+    def _test_init_device_mesh(world_size: int, rank: int) -> None:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(12346)
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(4)
+
+        testcase = TestCase()
+
+        manager = Mock(spec=Manager)
+        # Even though we only have 4 workers, we can still initialize (2, 4) mesh.
+        # That's because the replicate group is NOT phystically created in the
+        # real mesh but is virtually added to the mesh via ManagedDeviceMesh.
+        device_mesh = ft_init_device_mesh(
+            device_type="cpu",
+            mesh_shape=(2, world_size),
+            mesh_dim_names=("dp_replicate", "dp_shard"),
+            replicate_dim=0,
+            manager=manager,
+        )
+
+        testcase.assertTrue(
+            isinstance(device_mesh.get_group("dp_replicate"), ManagedProcessGroup)
+        )
+        testcase.assertTrue(
+            not isinstance(device_mesh.get_group("dp_shard"), ManagedProcessGroup)
+        )
+        replicate_group = device_mesh.get_group("dp_replicate")
+        testcase.assertEqual(
+            cast(ManagedProcessGroup, replicate_group)._manager, manager
+        )
+        replicate_mesh = device_mesh["dp_replicate"]
+        testcase.assertEqual(replicate_mesh.get_group(), replicate_group)
+
+        flatten_mesh = device_mesh._flatten("dp")
+        manager.num_participants.return_value = 0
+        testcase.assertEqual(flatten_mesh.size(), world_size)
+        manager.num_participants.return_value = 1
+        testcase.assertEqual(flatten_mesh.size(), world_size)
+        manager.num_participants.return_value = 2
+        testcase.assertEqual(flatten_mesh.size(), world_size * 2)
+
+        testcase.assertEqual(flatten_mesh.get_local_rank(), dist.get_rank())
+
+        device_mesh.get_coordinate()
+        buffer = io.BytesIO()
+        torch.save(device_mesh, buffer)
+        buffer.seek(0)
+        torch.load(buffer, weights_only=False)
+
+    def test_init_device_mesh(self) -> None:
+        with ProcessPoolExecutor(max_workers=4) as executor:
+            futures = []
+            for i in range(4):
+                future = executor.submit(self._test_init_device_mesh, 4, i)
+                futures.append(future)
+            for f in futures:
+                f.result()

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -20,7 +20,7 @@ import logging
 import queue
 import threading
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Tuple, Type, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.distributed as dist
@@ -31,16 +31,16 @@ import torch.multiprocessing as mp
 from torch.distributed import (
     BroadcastOptions,
     DeviceMesh,
-    get_rank,
-    init_device_mesh,
     PrefixStore,
     ProcessGroup as BaseProcessGroup,
     ProcessGroupGloo as BaseProcessGroupGloo,
     ProcessGroupNCCL as BaseProcessGroupNCCL,
     Store,
     TCPStore,
+    get_rank,
+    init_device_mesh,
 )
-from torch.distributed.distributed_c10d import _world, Work
+from torch.distributed.distributed_c10d import Work, _world
 from torch.futures import Future
 
 if TYPE_CHECKING:

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -861,7 +861,7 @@ def extend_device_mesh(
 
 
 class ManagedDeviceMesh(DeviceMesh):
-    replicate_pg_singleton: Optional["ManagedProcessGroup"]
+    replicate_pg_singleton: Optional["ManagedProcessGroup"] = None
 
     def __init__(
         self,
@@ -1093,17 +1093,7 @@ def ft_init_device_mesh(
         mesh_dim_names=tuple(_mesh_dim_names),
     )
 
-    if device_type == "cpu":
-        pg = ProcessGroupGloo()
-    elif device_type == "cuda":
-        pg = ProcessGroupNCCL()
-    else:
-        raise ValueError()
-
-    manager._pg = pg
     replicate_pg = ManagedProcessGroup(manager)
-    # We have to use MultiProcessTestCase, otherwise c10d will complain
-    # the same backend has been registered.
     replicate_pg.register(mesh_dim_names[replicate_dim])
 
     ManagedDeviceMesh.replicate_pg_singleton = replicate_pg

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -898,6 +898,7 @@ class ManagedDeviceMesh(DeviceMesh):
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
         self.__dict__.update(state)
+        assert self.replicate_pg_singleton is not None
         self.replicate_pg = self.replicate_pg_singleton
 
     def __getitem__(self, mesh_dim_names: Union[str, Tuple[str, ...]]) -> DeviceMesh:
@@ -921,10 +922,10 @@ class ManagedDeviceMesh(DeviceMesh):
                 assert self.mesh is not None
                 return self.mesh[mesh_dim_names]
             else:
-                assert self.mesh is not None
                 mesh_dim_names_wo_replicate = tuple(
                     n for n in mesh_dim_names if n != self.replicate_dim_name
                 )
+                assert self.mesh is not None
                 return ManagedDeviceMesh(
                     self.mesh[mesh_dim_names_wo_replicate],
                     mesh_dim_names,

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -10,37 +10,32 @@ import os
 import unittest
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import timedelta
-from typing import Any, cast, Dict, Tuple
-from unittest import skipUnless, TestCase
+from typing import Any, Dict, Tuple, cast
+from unittest import TestCase, skipUnless
 from unittest.mock import Mock
 
 import torch
 import torch.distributed as dist
 from torch import nn
 from torch._C._distributed_c10d import (
-    _resolve_process_group,
     AllgatherOptions,
     AllreduceOptions,
     BroadcastOptions,
     ReduceOp,
+    _resolve_process_group,
 )
 from torch.distributed import (
-    _functional_collectives,
-    get_world_size,
     ReduceOp,
     TCPStore,
     Work,
+    _functional_collectives,
+    get_world_size,
 )
 from torch.distributed.device_mesh import init_device_mesh
 
 from torchft.manager import Manager
 from torchft.process_group import (
-    _DummyWork,
-    _ErrorSwallowingWork,
-    _ManagedWork,
     ErrorSwallowingProcessGroupWrapper,
-    extend_device_mesh,
-    ft_init_device_mesh,
     ManagedProcessGroup,
     ProcessGroup,
     ProcessGroupBabyGloo,
@@ -49,6 +44,11 @@ from torchft.process_group import (
     ProcessGroupGloo,
     ProcessGroupNCCL,
     ProcessGroupWrapper,
+    _DummyWork,
+    _ErrorSwallowingWork,
+    _ManagedWork,
+    extend_device_mesh,
+    ft_init_device_mesh,
 )
 
 
@@ -370,64 +370,3 @@ class ProcessGroupTest(TestCase):
         self.assertEqual(manager.report_error.call_count, 0)
         self.assertEqual(manager.wrap_future.call_count, 1)
         self.assertEqual(manager.wait_quorum.call_count, 1)
-
-
-class DeviceMeshTest(TestCase):
-    @staticmethod
-    def _test_init_device_mesh(world_size: int, rank: int) -> None:
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
-        os.environ["MASTER_PORT"] = str(12346)
-        os.environ["RANK"] = str(rank)
-        os.environ["WORLD_SIZE"] = str(4)
-
-        testcase = TestCase()
-
-        manager = Mock(spec=Manager)
-        # Even though we only have 4 workers, we can still initialize (2, 4) mesh.
-        # That's because the replicate group is NOT phystically created in the
-        # real mesh but is virtually added to the mesh via ManagedDeviceMesh.
-        device_mesh = ft_init_device_mesh(
-            device_type="cpu",
-            mesh_shape=(2, world_size),
-            mesh_dim_names=("dp_replicate", "dp_shard"),
-            replicate_dim=0,
-            manager=manager,
-        )
-
-        testcase.assertTrue(
-            isinstance(device_mesh.get_group("dp_replicate"), ManagedProcessGroup)
-        )
-        testcase.assertTrue(
-            not isinstance(device_mesh.get_group("dp_shard"), ManagedProcessGroup)
-        )
-        replicate_group = device_mesh.get_group("dp_replicate")
-        testcase.assertEqual(
-            cast(ManagedProcessGroup, replicate_group)._manager, manager
-        )
-        replicate_mesh = device_mesh["dp_replicate"]
-        testcase.assertEqual(replicate_mesh.get_group(), replicate_group)
-
-        flatten_mesh = device_mesh._flatten("dp")
-        manager.num_participants.return_value = 0
-        testcase.assertEqual(flatten_mesh.size(), world_size)
-        manager.num_participants.return_value = 1
-        testcase.assertEqual(flatten_mesh.size(), world_size)
-        manager.num_participants.return_value = 2
-        testcase.assertEqual(flatten_mesh.size(), world_size * 2)
-
-        testcase.assertEqual(flatten_mesh.get_local_rank(), dist.get_rank())
-
-        device_mesh.get_coordinate()
-        buffer = io.BytesIO()
-        torch.save(device_mesh, buffer)
-        buffer.seek(0)
-        torch.load(buffer, weights_only=False)
-
-    def test_init_device_mesh(self) -> None:
-        with ProcessPoolExecutor(max_workers=4) as executor:
-            futures = []
-            for i in range(4):
-                future = executor.submit(self._test_init_device_mesh, 4, i)
-                futures.append(future)
-            for f in futures:
-                f.result()


### PR DESCRIPTION
There are missing gaps of ManagedDeviceMesh to be actually used in TorchTitan. This PR fixes the gpas:

1. ManagedDeviceMesh is now able to be torch.save()/torch.load().
2. ManagedDeviceMesh will lie if there are zero replicated group participants. Size 0 DeviceMesh will cause confusion for training loops.
3. Corretly returns coordinates.