### PR TITLE
Change how TorchFT manages user_state_dict

### DIFF
--- a/torchft/checkpointing.py
+++ b/torchft/checkpointing.py
@@ -172,7 +172,9 @@ class CheckpointServer(CheckpointTransport[T]):
             data = f.read()
 
         reader = io.BytesIO(data)
-        return torch.load(reader, weights_only=True)
+        # We have to set weights_only to True as there are some non-tensor
+        # states like lr_scheduler.
+        return torch.load(reader, weights_only=False)
 
     def address(self) -> str:
         """

--- a/torchft/checkpointing.py
+++ b/torchft/checkpointing.py
@@ -172,7 +172,7 @@ class CheckpointServer(CheckpointTransport[T]):
             data = f.read()
 
         reader = io.BytesIO(data)
-        # We have to set weights_only to True as there are some non-tensor
+        # We have to set weights_only to False as there are some non-tensor
         # states like lr_scheduler.
         return torch.load(reader, weights_only=False)
 

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -534,11 +534,11 @@ class Manager:
 
         self._logger.info("applying pending state dict")
 
+        assert self._pending_state_dict is not None, "checkpoint was not staged"
         assert (
             self._load_state_dict is not None
         ), "user load_state_dict is not initialized."
         self._load_state_dict(self._pending_state_dict["user"])
-        assert self._pending_state_dict is not None, "checkpoint was not staged"
         self._pending_state_dict = None
         self._logger.info("Loaded state dict.")
 

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -534,8 +534,11 @@ class Manager:
 
         self._logger.info("applying pending state dict")
 
-        assert self._pending_state_dict is not None, "checkpoint was not staged"
+        assert (
+            self._load_state_dict is not None
+        ), "user load_state_dict is not initialized."
         self._load_state_dict(self._pending_state_dict["user"])
+        assert self._pending_state_dict is not None, "checkpoint was not staged"
         self._pending_state_dict = None
         self._logger.info("Loaded state dict.")
 
@@ -607,6 +610,7 @@ class Manager:
         self._batches_committed = state_dict["batches_committed"]
 
     def _manager_state_dict(self) -> Dict[str, object]:
+        assert self._user_state_dict is not None, "user state_dict is not initialized."
         return {
             "user": self._user_state_dict(),
             "torchft": self.state_dict(),

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -225,7 +225,7 @@ class Manager:
         self._participating_world_size: int = 0
 
     def set_state_dict_fns(
-        self, load_state_dict: Callable[T, None], state_dict: Callable[[], T]
+        self, load_state_dict: Callable[[T], None], state_dict: Callable[[], T]
     ) -> None:
         self._load_state_dict = load_state_dict
         self._user_state_dict = state_dict

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -33,7 +33,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, cast, Dict, List, Optional, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypeVar, cast
 
 import torch
 from torch.distributed import ReduceOp, TCPStore

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -33,7 +33,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypeVar, cast
+from typing import Callable, cast, Dict, List, Optional, TYPE_CHECKING, TypeVar
 
 import torch
 from torch.distributed import ReduceOp, TCPStore
@@ -87,8 +87,8 @@ class Manager:
     def __init__(
         self,
         pg: "ProcessGroup",
-        load_state_dict: Callable[[T], None],
-        state_dict: Callable[[], T],
+        load_state_dict: Optional[Callable[[T], None]],
+        state_dict: Optional[Callable[[], T]],
         min_replica_size: int,
         use_async_quorum: bool = True,
         timeout: timedelta = timedelta(seconds=60),
@@ -144,7 +144,7 @@ class Manager:
                 transfering checkpoints to recovering replicas
         """
         self._load_state_dict = load_state_dict
-        self._state_dict = state_dict
+        self._user_state_dict = state_dict
         self._pending_state_dict: Optional[Dict[str, object]] = None
         self._use_async_quorum = use_async_quorum
         self._timeout = timeout
@@ -158,8 +158,6 @@ class Manager:
         rank = self._rank
         world_size = world_size or int(os.environ["WORLD_SIZE"])
         self._min_replica_size = min_replica_size
-
-        self._user_state_dict = state_dict
 
         if checkpoint_transport is None:
             checkpoint_transport = CheckpointServer[Dict[str, T]](
@@ -225,6 +223,12 @@ class Manager:
         # first step is 1
         self._participating_rank: Optional[int] = None
         self._participating_world_size: int = 0
+
+    def set_state_dict_fns(
+        self, load_state_dict: Callable[T, None], state_dict: Callable[[], T]
+    ) -> None:
+        self._load_state_dict = load_state_dict
+        self._user_state_dict = state_dict
 
     def shutdown(self, wait: bool = True) -> None:
         """
@@ -533,6 +537,7 @@ class Manager:
         assert self._pending_state_dict is not None, "checkpoint was not staged"
         self._load_state_dict(self._pending_state_dict["user"])
         self._pending_state_dict = None
+        self._logger.info("Loaded state dict.")
 
     def should_commit(self, timeout: Optional[timedelta] = None) -> bool:
         """

--- a/torchft/manager_test.py
+++ b/torchft/manager_test.py
@@ -7,13 +7,13 @@
 from datetime import timedelta
 from typing import Optional
 from unittest import TestCase
-from unittest.mock import create_autospec, MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import torch
 from torch.distributed import TCPStore
 
-from torchft.manager import Manager, MANAGER_ADDR_KEY, REPLICA_ID_KEY, WorldSizeMode
-from torchft.process_group import _DummyWork, ProcessGroup
+from torchft.manager import MANAGER_ADDR_KEY, REPLICA_ID_KEY, Manager, WorldSizeMode
+from torchft.process_group import ProcessGroup, _DummyWork
 from torchft.torchft import QuorumResult
 
 


### PR DESCRIPTION
This PR closes some state_dict gaps when integrating with TorchTitan:
1. User state_dict() and load_state_dict() functions can be initialized lazily.
2. Change weights_only to False for torch.load as we may have to load some non-tensor states.