### PR TITLE
Adds `reduce_scatter` into `torchft`

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -185,7 +185,7 @@ class ProcessGroup(BaseProcessGroup):
     def reduce_scatter(
         self,
         output_tensors: List[torch.Tensor],
-        input_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
         opts: ReduceScatterOptions,
     ) -> Work:
         """
@@ -306,7 +306,7 @@ class ProcessGroupWrapper(ProcessGroup):
     def reduce_scatter(
         self,
         output_tensors: List[torch.Tensor],
-        input_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
         opts: object,
     ) -> Work:
         return self.parent.reduce_scatter(output_tensors, input_tensors, opts)
@@ -424,10 +424,10 @@ class ProcessGroupDummy(ProcessGroup):
     def reduce_scatter(
         self,
         output_tensors: List[torch.Tensor],
-        input_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
         opts: object,
     ) -> Work:
-        for o, i in zip(output_tensors, input_tensors):
+        for o, i in zip(output_tensors, input_tensors[0]):
             o.copy_(i)
 
         res = _DummyWork(output_tensors)
@@ -1013,7 +1013,6 @@ class ProcessGroupBaby(ProcessGroup):
             for tensor in tensor_list:
                 if not tensor.is_shared():
                     tensor.share_memory_()
-
         return self._run_func("reduce_scatter", output_tensors, input_tensors, opts)
 
     def size(self) -> int:

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -58,6 +58,7 @@ from torch.distributed.distributed_c10d import (
     AllreduceOptions,
     BroadcastOptions,
     ReduceOp,
+    ReduceScatterOptions,
     Work,
 )
 from torch.futures import Future
@@ -180,6 +181,20 @@ class ProcessGroup(BaseProcessGroup):
         opts.rootRank = root
         return self.broadcast([tensor], opts)
 
+    # pyre-fixme[14]: inconsistent override
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: ReduceScatterOptions,
+    ) -> Work:
+        """
+        Reduces, then scatters a list of tensors to all processes in a group.
+
+        See torch.distributed.reduce_scatter for more details.
+        """
+        raise NotImplementedError("not implemented")
+
     def size(self) -> int:
         raise NotImplementedError("not implemented")
 
@@ -288,6 +303,14 @@ class ProcessGroupWrapper(ProcessGroup):
     def broadcast(self, tensor_list: List[torch.Tensor], opts: object) -> Work:
         return self.parent.broadcast(tensor_list, opts)
 
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: object,
+    ) -> Work:
+        return self.parent.reduce_scatter(output_tensors, input_tensors, opts)
+
     def size(self) -> int:
         return self.parent.size()
 
@@ -375,11 +398,6 @@ class ProcessGroupDummy(ProcessGroup):
     def configure(self, store_addr: str, rank: int, world_size: int) -> None:
         self.configure_count += 1
 
-    def broadcast(self, tensor_list: List[torch.Tensor], opts: object) -> Work:
-        res = _DummyWork(tensor_list)
-        self._work.append(res)
-        return res
-
     def allgather(
         self,
         output_tensors: List[List[torch.Tensor]],
@@ -395,6 +413,24 @@ class ProcessGroupDummy(ProcessGroup):
 
     def allreduce(self, tensors: List[torch.Tensor], opts: object) -> Work:
         res = _DummyWork(tensors)
+        self._work.append(res)
+        return res
+
+    def broadcast(self, tensor_list: List[torch.Tensor], opts: object) -> Work:
+        res = _DummyWork(tensor_list)
+        self._work.append(res)
+        return res
+
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: object,
+    ) -> Work:
+        for o, i in zip(output_tensors, input_tensors):
+            o.copy_(i)
+
+        res = _DummyWork(output_tensors)
         self._work.append(res)
         return res
 
@@ -959,6 +995,26 @@ class ProcessGroupBaby(ProcessGroup):
                 tensor.share_memory_()
 
         return self._run_func("broadcast", tensor_list, opts)
+
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
+        opts: ReduceScatterOptions,
+    ) -> Work:
+        assert isinstance(output_tensors, list), "input must be list"
+        assert isinstance(input_tensors, list), "input must be list"
+
+        for tensor in output_tensors:
+            if not tensor.is_shared():
+                tensor.share_memory_()
+
+        for tensor_list in input_tensors:
+            for tensor in tensor_list:
+                if not tensor.is_shared():
+                    tensor.share_memory_()
+
+        return self._run_func("reduce_scatter", output_tensors, input_tensors, opts)
 
     def size(self) -> int:
         return self._world_size

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1091,6 +1091,25 @@ class ProcessGroupBabyGloo(ProcessGroupBaby):
     def getBackendName(self) -> str:
         return "torchft-baby-gloo"
 
+    # pyre-fixme[15]: inconsistent override
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
+        opts: ReduceScatterOptions,
+    ) -> None:
+        """
+        This function is a placeholder for the reduce_scatter operation in the
+        ProcessGroupGloo class. However, this operation is not supported by the
+        Gloo backend, and thus, calling this function will raise a
+        NotImplementedError.
+
+        Raises:
+            NotImplementedError: Always raised since reduce_scatter is not
+            supported by ProcessGroupGloo.
+        """
+        raise NotImplementedError("ProcessGroupGloo does not support reduce_scatter.")
+
 
 class ProcessGroupBabyNCCL(ProcessGroupBaby):
     """

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -329,13 +329,13 @@ class ProcessGroupGloo(ProcessGroupWrapper):
         This function is a placeholder for the reduce_scatter operation in the
         ProcessGroupGloo class. However, this operation is not supported by the
         Gloo backend, and thus, calling this function will raise a
-        NotImplementedError.
+        RuntimeError.
 
         Raises:
-            NotImplementedError: Always raised since reduce_scatter is not
+            RuntimeError: Always raised since reduce_scatter is not
             supported by ProcessGroupGloo.
         """
-        raise NotImplementedError("ProcessGroupGloo does not support reduce_scatter.")
+        raise RuntimeError("ProcessGroupGloo does not support reduce_scatter.")
 
 
 class ProcessGroupNCCL(ProcessGroupWrapper):
@@ -1131,15 +1131,13 @@ class ProcessGroupBabyGloo(ProcessGroupBaby):
         This function is a placeholder for the reduce_scatter operation in the
         ProcessGroupGloo class. However, this operation is not supported by the
         Gloo backend, and thus, calling this function will raise a
-        NotImplementedError.
+        RuntimeError.
 
         Raises:
-            NotImplementedError: Always raised since reduce_scatter is not
+            RuntimeError: Always raised since reduce_scatter is not
             supported by ProcessGroupGloo.
         """
-        raise NotImplementedError(
-            "ProcessGroupBabyGloo does not support reduce_scatter."
-        )
+        raise RuntimeError("ProcessGroupBabyGloo does not support reduce_scatter.")
 
 
 class ProcessGroupBabyNCCL(ProcessGroupBaby):

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -318,6 +318,25 @@ class ProcessGroupGloo(ProcessGroupWrapper):
     def getBackendName(self) -> str:
         return "torchft-gloo"
 
+    # pyre-fixme[14,15]: inconsistent override
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
+        opts: ReduceScatterOptions,
+    ) -> None:
+        """
+        This function is a placeholder for the reduce_scatter operation in the
+        ProcessGroupGloo class. However, this operation is not supported by the
+        Gloo backend, and thus, calling this function will raise a
+        NotImplementedError.
+
+        Raises:
+            NotImplementedError: Always raised since reduce_scatter is not
+            supported by ProcessGroupGloo.
+        """
+        raise NotImplementedError("ProcessGroupGloo does not support reduce_scatter.")
+
 
 class ProcessGroupNCCL(ProcessGroupWrapper):
     """
@@ -1118,7 +1137,9 @@ class ProcessGroupBabyGloo(ProcessGroupBaby):
             NotImplementedError: Always raised since reduce_scatter is not
             supported by ProcessGroupGloo.
         """
-        raise NotImplementedError("ProcessGroupGloo does not support reduce_scatter.")
+        raise NotImplementedError(
+            "ProcessGroupBabyGloo does not support reduce_scatter."
+        )
 
 
 class ProcessGroupBabyNCCL(ProcessGroupBaby):

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1037,7 +1037,15 @@ class _PickleSafeOptions:
             return tuple(cls.safe_args(arg) for arg in args)
         elif isinstance(args, list):
             return [cls.safe_args(arg) for arg in args]
-        elif isinstance(args, (AllreduceOptions, AllgatherOptions, BroadcastOptions)):
+        elif isinstance(
+            args,
+            (
+                AllreduceOptions,
+                AllgatherOptions,
+                BroadcastOptions,
+                ReduceScatterOptions,
+            ),
+        ):
             return cls.from_torch(args)
         else:
             return args

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -61,6 +61,31 @@ def dummy_init_pg() -> None:
         )
 
 
+def _should_run_collective(collective_str: str, backend_str: str, device: str) -> bool:
+    """Verify if the collective is supported by the backend and device.
+
+    See https://pytorch.org/docs/stable/distributed.html#backends for the
+    supported collectives / backends / devices matrix.
+
+    """
+    if "nccl" in backend_str.lower():
+        # all collectives are supported for NCCL/CUDA but none on CPU.
+        return device == "cuda"
+    elif "gloo" in backend_str.lower():
+        if device == "cuda":
+            # GLOO/GPU only supports broadcast and all_reduce.
+            if collective_str in ["broadcast", "all_reduce"]:
+                return True
+            return False
+        else:  # cpu
+            if collective_str in ["reduce_scatter", "all_to_all"]:
+                return False
+            return True
+    else:
+        # Non defined backends (e.g. ErrorSwallowing) should continue to work.
+        return True
+
+
 def _test_pg(
     pg: ProcessGroup,
     example_tensor: torch.Tensor = torch.randn((2, 3), dtype=torch.float32),
@@ -95,10 +120,25 @@ def _test_pg(
         ("allgather", (output_tensors, [input_tensor], AllgatherOptions())),
         ("broadcast", (tensor_list, BroadcastOptions())),
         ("broadcast_one", (input_tensor, 0)),
-        ("reduce_scatter", (output_tensors, [input_tensor], ReduceScatterOptions())),
+        (
+            "reduce_scatter",
+            (output_tensors[0], [[input_tensor]], ReduceScatterOptions()),
+        ),
     ]
     works: Dict[str, dist._Work] = {}
+
+    try:
+        backend_str = pg.getBackendName()
+        device = example_tensor.device
+        if type(device) is torch.device:
+            device = device.type
+    except NotImplementedError as e:
+        backend_str = ""
+        device = ""
+
     for coll_str, args in collectives:
+        if not _should_run_collective(coll_str, backend_str=backend_str, device=device):
+            continue
         coll = getattr(pg, coll_str)
         work = coll(*args)
         works[coll_str] = work

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -23,6 +23,7 @@ from torch._C._distributed_c10d import (
     AllreduceOptions,
     BroadcastOptions,
     ReduceOp,
+    ReduceScatterOptions,
     _resolve_process_group,
 )
 from torch.distributed import (
@@ -94,6 +95,7 @@ def _test_pg(
         ("allgather", (output_tensors, [input_tensor], AllgatherOptions())),
         ("broadcast", (tensor_list, BroadcastOptions())),
         ("broadcast_one", (input_tensor, 0)),
+        ("reduce_scatter", (output_tensors, [input_tensor], ReduceScatterOptions())),
     ]
     works: Dict[str, dist._Work] = {}
     for coll_str, args in collectives:


### PR DESCRIPTION
# What does this PR do?
Partially addresses https://github.com/pytorch/torchft/issues/97 by adding `reduce_scatter` into `torchft`.

Concretely, this consists of a few pieces: 
- Introducing `reduce_scatter` into the `ProcessGroup` following the signature [here](https://github.com/pytorch/pytorch/blob/11f69808c64a65c68a4452250ba7719dcff27c78/torch/csrc/distributed/c10d/PyProcessGroup.hpp#L203
- In `ProcessGroup*` we essentially follow the behavior of other collectives:
  - In `ProcessGroupWrapper`, it depends on the parent implementation
  - In `ProcessGroupDummy`, it writes from the first input into output
  - In `ProcessGroupBaby`, it asserts inputs and moves underlying storage into shared memory 
- Add `ReduceScatterOptions` in `_PickleSafeOptions`
- Introduces `reduce_scatter` as an option in `_test_pg`, however this necessitated a new function (named `_should_run_collective`) which was needed as e.g. GLOO does not support `reduce_scatter`. This function essentially takes the collective, backend and device and copies the logic of the [published supported collective matrix](https://pytorch.org/docs/stable/distributed.html#backends). 

# Tests
Presubmits, and:
```
$ pytest torchft/process_group_test.py 
============================================= test session starts =============================================
platform linux -- Python 3.10.16, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/allencwang/workspace/torchft
configfile: pytest.ini
plugins: typeguard-2.13.3
collected 16 items                                                                                            

torchft/process_group_test.py ................                                                          [100%]

============================================= 16 passed in 31.44s =============================================
[rank0]:[W206 14:54:24.777939032 CudaIPCTypes.cpp:16] Producer process has been terminated before all shared CUDA tensors released. See Note [Sharing CUDA tensors]
```

# Next steps
The logic of `_should_run_collective` is a bit confusing, as it allows "non defined backends" like `ErrorSwallowing*` through, to mimic the old behavior before this change. Testing here could become a bit unwieldy as we add more collectives and so a future step could be to refactor the testing. 

One nice change could be to parameterize tests by the collective. This will make potentially failing collectives more explicit and will reduce the time it takes to run individual tests. Likely can do this in the next PR.