### PR TITLE
Refactors `process_group_tests.py`

### DIFF
--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -64,7 +64,7 @@ def run_collectives(
     pg: ProcessGroup,
     collectives: List[str],
     example_tensor: torch.Tensor = torch.randn((2, 3), dtype=torch.float32),
-) -> List[Work]:
+) -> List[dist._Work]:
     """Run a single collective."""
     shape: torch.Size = example_tensor.shape
     dtype: torch.dtype = example_tensor.dtype
@@ -109,6 +109,7 @@ def run_collectives(
             for item in tensors_to_check:
                 check_tensors(item)
 
+    assert len(works) == len(tensors_to_check_list)
     for work, tensors_to_check in zip(works, tensors_to_check_list):
         work.wait()
         fut = work.get_future()

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -100,15 +100,12 @@ def run_collective(
     coll = getattr(pg, collective)
     args_list = _build_args(pg=pg, collective=collective, example_tensor=example_tensor)
     works: Dict[str, dist._Work] = {}
+
     def check_tensors(arg: Any) -> None:  # pyre-ignore[2]
         """Recursively check tensors for expected shape and dtype."""
         if isinstance(arg, torch.Tensor):
-            assert (
-                arg.dtype == dtype
-            ), f"Output dtype mismatch: {arg.dtype} != {dtype}"
-            assert (
-                arg.shape == shape
-            ), f"Output shape mismatch: {arg.shape} != {shape}"
+            assert arg.dtype == dtype, f"Output dtype mismatch: {arg.dtype} != {dtype}"
+            assert arg.shape == shape, f"Output shape mismatch: {arg.shape} != {shape}"
         elif isinstance(arg, (list, tuple)):
             for item in arg:
                 check_tensors(item)


### PR DESCRIPTION
# What does this PR do?
As part of https://github.com/pytorch/torchft/issues/97, this PR refactors `process_group_test`:
- Renames up `_test_pg` to `run_collectives` and extending it to accept a given list of collectives by name.
- Breaks up `ProcessGroupTest` into three tests: `GlooTest`, `NCCLTests` and `DummyTests`:
  - `GlooTest` logically tests every test using `gloo`, `NCCLTest` with NCCL, etc.
  - This allows some niceties, like marking once that we want to skip all NCCL tests 
- Adds `shutdown()` and garbage collection etc. to avoid extraneous messages & warnings like
```
Traceback (most recent call last):
  File "/home/allencwang/workspace/torchft/torchft/process_group.py", line 824, in _future_handler
    cmd = future_queue.get(timeout=timedelta(seconds=10.0))
  File "/home/allencwang/workspace/torchft/torchft/multiprocessing.py", line 45, in get
    raise RuntimeError(f"process is not alive {self._p.exitcode}")
RuntimeError: process is not alive -15
[rank0]:[W207 10:50:12.933128109 CudaIPCTypes.cpp:16] Producer process has been terminated before all shared CUDA tensors released. See Note [Sharing CUDA tensors]
```

# Why is this needed?
As part of https://github.com/pytorch/torchft/pull/102, I noticed that there were some mismatches between which collectives ran on which backends (matrix is [here](https://pytorch.org/docs/stable/distributed.html#backends)). Therefore this logical grouping of tests by backend allows us to define which collectives should be tested explicitly

