### PR TITLE
checkpointing: move to subfolder

### DIFF
--- a/torchft/checkpointing/__init__.py
+++ b/torchft/checkpointing/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Checkpointing
+==============
+
+This module implements methods for checkpointing and resuming training from a checkpoint.
+"""
+
+from torchft.checkpointing.http_transport import HTTPTransport
+from torchft.checkpointing.transport import CheckpointTransport
+
+__all__ = [
+    "HTTPTransport",
+    "CheckpointTransport",
+]

--- a/torchft/checkpointing/http_transport_test.py
+++ b/torchft/checkpointing/http_transport_test.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from torchft.checkpointing import CheckpointServer, _timed_acquire
+from torchft.checkpointing.http_transport import HTTPTransport, _timed_acquire
 
 
 class TestCheckpointing(TestCase):
@@ -18,7 +18,7 @@ class TestCheckpointing(TestCase):
         expected = {"state": "dict"}
         state_dict_fn = MagicMock()
         state_dict_fn.return_value = expected
-        server = CheckpointServer(
+        server = HTTPTransport(
             timeout=timedelta(seconds=10),
         )
 
@@ -58,7 +58,7 @@ class TestCheckpointing(TestCase):
         server.shutdown()
 
     def test_checkpoint_server_locking(self) -> None:
-        server = CheckpointServer(
+        server = HTTPTransport(
             timeout=timedelta(seconds=10),
         )
 

--- a/torchft/checkpointing/transport.py
+++ b/torchft/checkpointing/transport.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from datetime import timedelta
+from typing import Generic, List, TypeVar
+
+T = TypeVar("T")
+
+
+class CheckpointTransport(Generic[T], ABC):
+    @abstractmethod
+    def metadata(self) -> str:
+        """
+        Returns a string that will be used by the remote CheckpointTransport to fetch the checkpoint.
+        """
+        ...
+
+    @abstractmethod
+    def send_checkpoint(
+        self, dst_ranks: List[int], step: int, state_dict: T, timeout: timedelta
+    ) -> None:
+        """
+        Sends the checkpoint, only called when there is a rank that is behind.
+
+        This may be async.
+
+        Args:
+            dst_ranks: the ranks to send to
+            step: the step number to send
+            state_dict: the state dict to send
+            timeout: the timeout to wait for the checkpoint to be sent
+        """
+        ...
+
+    def disallow_checkpoint(self) -> None:
+        """
+        Called after send_checkpoint to wait for the checkpoint to be sent.
+
+        Once this returns, the state_dict may be mutated so no further data should be sent.
+        """
+        ...
+
+    @abstractmethod
+    def recv_checkpoint(
+        self, src_rank: int, metadata: str, step: int, timeout: timedelta
+    ) -> T:
+        """
+        Receives the checkpoint from the given rank.
+
+        Args:
+            src_rank: the rank to receive the checkpoint from
+            metadata: the metadata returned by the remote CheckpointTransport
+            step: the step number to receive
+            timeout: the timeout to wait for the checkpoint
+        """
+        ...
+
+    def shutdown(self, wait: bool = True) -> None:
+        """
+        Called to shutdown the checkpoint transport.
+
+        Args:
+            wait: whether to wait for the transport to shutdown
+        """

--- a/torchft/fsdp_test.py
+++ b/torchft/fsdp_test.py
@@ -66,8 +66,8 @@ class FSDPTest(unittest.TestCase):
     # pyre-ignore[56]: Pyre was not able to infer the type of argument
     @unittest.skipIf(torch.cuda.device_count() < 4, "Not enough GPUs")
     def test_fsdp(self) -> None:
-        multiprocessing.set_start_method("spawn")
-        with ProcessPoolExecutor(max_workers=4) as executor:
+        context = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(max_workers=4, mp_context=context) as executor:
             futures = []
             for i in range(4):
                 future = executor.submit(self._test_fsdp, 4, i)

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypeVar, cast
 import torch
 from torch.distributed import ReduceOp, TCPStore
 
-from torchft.checkpointing import CheckpointServer, CheckpointTransport
+from torchft.checkpointing import CheckpointTransport, HTTPTransport
 from torchft.futures import future_timeout
 from torchft.torchft import Manager as _Manager, ManagerClient
 
@@ -141,7 +141,7 @@ class Manager:
             replica_id: if rank==0, the replica_id for this group
             hostname: if rank==0, the hostname to advertise to the lighthouse server
             checkpoint_transport: the checkpoint transport to use for
-                transfering checkpoints to recovering replicas
+                transfering checkpoints to recovering replicas, defaults to HTTPTransport
         """
         self._load_state_dict = load_state_dict
         self._user_state_dict = state_dict
@@ -160,7 +160,7 @@ class Manager:
         self._min_replica_size = min_replica_size
 
         if checkpoint_transport is None:
-            checkpoint_transport = CheckpointServer[Dict[str, T]](
+            checkpoint_transport = HTTPTransport[Dict[str, T]](
                 timeout=timeout,
             )
 


### PR DESCRIPTION
This restructures `torchft.checkpointing` to move `CheckpointServer` to it's own file and rename it `HTTPTransport` in preparation for the new `PGTransport`.

This new structure will make it easier to add in changes for PGTransport as well as parallel/streaming HTTP transfers.

It also has a small fix to `fsdp_test` due to tests running in a different order now.

Test plan:

```
pytest
```