### PR TITLE
Adds more collectives to ProcessGroups

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -185,7 +185,7 @@ class ProcessGroup(BaseProcessGroup):
     def reduce_scatter(
         self,
         output_tensors: List[torch.Tensor],
-        input_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
         opts: ReduceScatterOptions,
     ) -> Work:
         """
@@ -306,7 +306,7 @@ class ProcessGroupWrapper(ProcessGroup):
     def reduce_scatter(
         self,
         output_tensors: List[torch.Tensor],
-        input_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
         opts: object,
     ) -> Work:
         return self.parent.reduce_scatter(output_tensors, input_tensors, opts)
@@ -424,10 +424,10 @@ class ProcessGroupDummy(ProcessGroup):
     def reduce_scatter(
         self,
         output_tensors: List[torch.Tensor],
-        input_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
         opts: object,
     ) -> Work:
-        for o, i in zip(output_tensors, input_tensors):
+        for o, i in zip(output_tensors, input_tensors[0]):
             o.copy_(i)
 
         res = _DummyWork(output_tensors)
@@ -1013,7 +1013,6 @@ class ProcessGroupBaby(ProcessGroup):
             for tensor in tensor_list:
                 if not tensor.is_shared():
                     tensor.share_memory_()
-
         return self._run_func("reduce_scatter", output_tensors, input_tensors, opts)
 
     def size(self) -> int:

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -58,6 +58,7 @@ from torch.distributed.distributed_c10d import (
     AllreduceOptions,
     BroadcastOptions,
     ReduceOp,
+    ReduceScatterOptions,
     Work,
 )
 from torch.futures import Future
@@ -180,6 +181,20 @@ class ProcessGroup(BaseProcessGroup):
         opts.rootRank = root
         return self.broadcast([tensor], opts)
 
+    # pyre-fixme[14]: inconsistent override
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: ReduceScatterOptions,
+    ) -> Work:
+        """
+        Reduces, then scatters a list of tensors to all processes in a group.
+
+        See torch.distributed.reduce_scatter for more details.
+        """
+        raise NotImplementedError("not implemented")
+
     def size(self) -> int:
         raise NotImplementedError("not implemented")
 
@@ -288,6 +303,14 @@ class ProcessGroupWrapper(ProcessGroup):
     def broadcast(self, tensor_list: List[torch.Tensor], opts: object) -> Work:
         return self.parent.broadcast(tensor_list, opts)
 
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: object,
+    ) -> Work:
+        return self.parent.reduce_scatter(output_tensors, input_tensors, opts)
+
     def size(self) -> int:
         return self.parent.size()
 
@@ -375,11 +398,6 @@ class ProcessGroupDummy(ProcessGroup):
     def configure(self, store_addr: str, rank: int, world_size: int) -> None:
         self.configure_count += 1
 
-    def broadcast(self, tensor_list: List[torch.Tensor], opts: object) -> Work:
-        res = _DummyWork(tensor_list)
-        self._work.append(res)
-        return res
-
     def allgather(
         self,
         output_tensors: List[List[torch.Tensor]],
@@ -395,6 +413,24 @@ class ProcessGroupDummy(ProcessGroup):
 
     def allreduce(self, tensors: List[torch.Tensor], opts: object) -> Work:
         res = _DummyWork(tensors)
+        self._work.append(res)
+        return res
+
+    def broadcast(self, tensor_list: List[torch.Tensor], opts: object) -> Work:
+        res = _DummyWork(tensor_list)
+        self._work.append(res)
+        return res
+
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: object,
+    ) -> Work:
+        for o, i in zip(output_tensors, input_tensors):
+            o.copy_(i)
+
+        res = _DummyWork(output_tensors)
         self._work.append(res)
         return res
 
@@ -959,6 +995,26 @@ class ProcessGroupBaby(ProcessGroup):
                 tensor.share_memory_()
 
         return self._run_func("broadcast", tensor_list, opts)
+
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
+        opts: ReduceScatterOptions,
+    ) -> Work:
+        assert isinstance(output_tensors, list), "input must be list"
+        assert isinstance(input_tensors, list), "input must be list"
+
+        for tensor in output_tensors:
+            if not tensor.is_shared():
+                tensor.share_memory_()
+
+        for tensor_list in input_tensors:
+            for tensor in tensor_list:
+                if not tensor.is_shared():
+                    tensor.share_memory_()
+
+        return self._run_func("reduce_scatter", output_tensors, input_tensors, opts)
 
     def size(self) -> int:
         return self._world_size

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1091,6 +1091,25 @@ class ProcessGroupBabyGloo(ProcessGroupBaby):
     def getBackendName(self) -> str:
         return "torchft-baby-gloo"
 
+    # pyre-fixme[15]: inconsistent override
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
+        opts: ReduceScatterOptions,
+    ) -> None:
+        """
+        This function is a placeholder for the reduce_scatter operation in the
+        ProcessGroupGloo class. However, this operation is not supported by the
+        Gloo backend, and thus, calling this function will raise a
+        NotImplementedError.
+
+        Raises:
+            NotImplementedError: Always raised since reduce_scatter is not
+            supported by ProcessGroupGloo.
+        """
+        raise NotImplementedError("ProcessGroupGloo does not support reduce_scatter.")
+
 
 class ProcessGroupBabyNCCL(ProcessGroupBaby):
     """

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -132,6 +132,7 @@ class ProcessGroup(BaseProcessGroup):
     ) -> Work:
         """
         Reduces the tensor data across all machines in such a way that all get the final result.
+
         See torch.distributed.all_reduce for more details.
         """
         raise NotImplementedError("not implemented")
@@ -143,6 +144,7 @@ class ProcessGroup(BaseProcessGroup):
     ) -> Work:
         """
         Performs an all_reduce operation in a coalesced manner.
+
         See torch.distributed.all_reduce_coalesced for more details.
         """
         raise NotImplementedError("not implemented")
@@ -158,6 +160,7 @@ class ProcessGroup(BaseProcessGroup):
     ) -> Work:
         """
         Performs an all_to_all operation.
+
         See torch.distributed.all_to_all_single for more details.
         """
         raise NotImplementedError("not implemented")
@@ -165,6 +168,7 @@ class ProcessGroup(BaseProcessGroup):
     def barrier(self, opts: BarrierOptions) -> Work:
         """
         Synchronizes all processes.
+
         See torch.distributed.barrier for more details.
         """
         raise NotImplementedError("not implemented")
@@ -189,12 +193,8 @@ class ProcessGroup(BaseProcessGroup):
     def recv(self, tensors: List[torch.Tensor], src_rank: int, tag: int) -> Work:
         """
         Receives a list of tensors from the process with rank `rank`.
-        Args:
-            tensors (List[torch.Tensor]): The list of tensors to fill.
-            rank (int): The rank of the process to receive from.
-            tag (int): The tag to match for the receive.
-        Returns:
-            Work: A work handle representing the asynchronous receive operation.
+
+        See torch.distributed.recv for more details.
         """
         raise NotImplementedError("not implemented")
 
@@ -216,12 +216,8 @@ class ProcessGroup(BaseProcessGroup):
     def send(self, tensors: List[torch.Tensor], dst_rank: int, tag: int) -> Work:
         """
         Sends a list of tensors to the process with rank `dst_rank`.
-        Args:
-            tensors (List[torch.Tensor]): The list of tensors to send.
-            dst_rank (int): The rank of the process to send to.
-            tag (int): The tag to match for the send.
-        Returns:
-            Work: A work handle representing the asynchronous send operation.
+
+        See torch.distributed.send for more details.
         """
         raise NotImplementedError("not implemented")
 

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1345,6 +1345,9 @@ class ProcessGroupBabyNCCL(ProcessGroupBaby):
     def getBackendName(self) -> str:
         return "torchft-baby-nccl"
 
+    def shutdown(self) -> None:
+        super().shutdown()
+
 
 def extend_device_mesh(
     mesh: DeviceMesh, pg: ProcessGroup, name: str = "dp", dim: int = 0

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1037,7 +1037,15 @@ class _PickleSafeOptions:
             return tuple(cls.safe_args(arg) for arg in args)
         elif isinstance(args, list):
             return [cls.safe_args(arg) for arg in args]
-        elif isinstance(args, (AllreduceOptions, AllgatherOptions, BroadcastOptions)):
+        elif isinstance(
+            args,
+            (
+                AllreduceOptions,
+                AllgatherOptions,
+                BroadcastOptions,
+                ReduceScatterOptions,
+            ),
+        ):
             return cls.from_torch(args)
         else:
             return args

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1345,9 +1345,6 @@ class ProcessGroupBabyNCCL(ProcessGroupBaby):
     def getBackendName(self) -> str:
         return "torchft-baby-nccl"
 
-    def shutdown(self) -> None:
-        super().shutdown()
-
 
 def extend_device_mesh(
     mesh: DeviceMesh, pg: ProcessGroup, name: str = "dp", dim: int = 0

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -21,6 +21,7 @@ from torch import nn
 from torch._C._distributed_c10d import (
     AllgatherOptions,
     AllreduceOptions,
+    AllreduceCoalescedOptions,
     AllToAllOptions,
     BroadcastOptions,
     ReduceOp,
@@ -93,7 +94,9 @@ def _test_pg(
     collectives = [
         ("allreduce", ([input_tensor], AllreduceOptions())),
         ("allreduce", ([input_tensor], ReduceOp.SUM)),
+        #("allreduce_coalesced", ([input_tensor], AllreduceCoalescedOptions())),
         ("allgather", (output_tensors, [input_tensor], AllgatherOptions())),
+        #("allgather_into_tensor_coalesced", (output_tensors[0], [input_tensor], AllgatherOptions())),
         ("broadcast", (tensor_list, BroadcastOptions())),
         ("broadcast_one", (input_tensor, 0)),
         (

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -20,8 +20,8 @@ import torch.distributed as dist
 from torch import nn
 from torch._C._distributed_c10d import (
     AllgatherOptions,
-    AllreduceOptions,
     AllreduceCoalescedOptions,
+    AllreduceOptions,
     AllToAllOptions,
     BroadcastOptions,
     ReduceOp,
@@ -94,9 +94,12 @@ def _test_pg(
     collectives = [
         ("allreduce", ([input_tensor], AllreduceOptions())),
         ("allreduce", ([input_tensor], ReduceOp.SUM)),
-        #("allreduce_coalesced", ([input_tensor], AllreduceCoalescedOptions())),
+        ("allreduce_coalesced", ([input_tensor], AllreduceCoalescedOptions())),
         ("allgather", (output_tensors, [input_tensor], AllgatherOptions())),
-        #("allgather_into_tensor_coalesced", (output_tensors[0], [input_tensor], AllgatherOptions())),
+        (
+            "allgather_into_tensor_coalesced",
+            (output_tensors[0], [input_tensor], AllgatherOptions()),
+        ),
         ("broadcast", (tensor_list, BroadcastOptions())),
         ("broadcast_one", (input_tensor, 0)),
         (

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -61,6 +61,31 @@ def dummy_init_pg() -> None:
         )
 
 
+def _should_run_collective(collective_str: str, backend_str: str, device: str) -> bool:
+    """Verify if the collective is supported by the backend and device.
+
+    See https://pytorch.org/docs/stable/distributed.html#backends for the
+    supported collectives / backends / devices matrix.
+
+    """
+    if "nccl" in backend_str.lower():
+        # all collectives are supported for NCCL/CUDA but none on CPU.
+        return device == "cuda"
+    elif "gloo" in backend_str.lower():
+        if device == "cuda":
+            # GLOO/GPU only supports broadcast and all_reduce.
+            if collective_str in ["broadcast", "all_reduce"]:
+                return True
+            return False
+        else:  # cpu
+            if collective_str in ["reduce_scatter", "all_to_all"]:
+                return False
+            return True
+    else:
+        # Non defined backends (e.g. ErrorSwallowing) should continue to work.
+        return True
+
+
 def _test_pg(
     pg: ProcessGroup,
     example_tensor: torch.Tensor = torch.randn((2, 3), dtype=torch.float32),
@@ -95,10 +120,25 @@ def _test_pg(
         ("allgather", (output_tensors, [input_tensor], AllgatherOptions())),
         ("broadcast", (tensor_list, BroadcastOptions())),
         ("broadcast_one", (input_tensor, 0)),
-        ("reduce_scatter", (output_tensors, [input_tensor], ReduceScatterOptions())),
+        (
+            "reduce_scatter",
+            (output_tensors[0], [[input_tensor]], ReduceScatterOptions()),
+        ),
     ]
     works: Dict[str, dist._Work] = {}
+
+    try:
+        backend_str = pg.getBackendName()
+        device = example_tensor.device
+        if type(device) is torch.device:
+            device = device.type
+    except NotImplementedError as e:
+        backend_str = ""
+        device = ""
+
     for coll_str, args in collectives:
+        if not _should_run_collective(coll_str, backend_str=backend_str, device=device):
+            continue
         coll = getattr(pg, coll_str)
         work = coll(*args)
         works[coll_str] = work

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -71,6 +71,7 @@ def _test_pg(
     """
     Helper function to test a set of collective operations on a given process group.
     """
+
     shape: torch.Size = example_tensor.shape
     dtype: torch.dtype = example_tensor.dtype
 
@@ -268,7 +269,6 @@ class ProcessGroupTest(TestCase):
         a = ProcessGroupBabyGloo(timeout=timedelta(seconds=0.01))
         with self.assertRaisesRegex(TimeoutError, "timed out after 0.01 seconds"):
             a.configure(store_addr, 0, 2)
-        a.shutdown()
 
     def test_reconfigure_baby_process_group(self) -> None:
         store = TCPStore(
@@ -305,7 +305,6 @@ class ProcessGroupTest(TestCase):
         self.assertFalse(future_queue_2.closed())
         assert p_2 is not None
         self.assertTrue(p_2.is_alive())
-        a.shutdown()
 
     def test_baby_gloo_apis(self) -> None:
         store = TCPStore(
@@ -323,7 +322,6 @@ class ProcessGroupTest(TestCase):
         gc.collect()
 
         self.assertEqual(a.num_active_work(), 0)
-        a.shutdown()
 
     def test_baby_gloo_send_recv(self) -> None:
         store = TCPStore(

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -21,6 +21,7 @@ from torch import nn
 from torch._C._distributed_c10d import (
     AllgatherOptions,
     AllreduceOptions,
+    AllToAllOptions,
     BroadcastOptions,
     ReduceOp,
     ReduceScatterOptions,

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -23,6 +23,7 @@ from torch._C._distributed_c10d import (
     AllreduceOptions,
     BroadcastOptions,
     ReduceOp,
+    ReduceScatterOptions,
     _resolve_process_group,
 )
 from torch.distributed import (
@@ -94,6 +95,7 @@ def _test_pg(
         ("allgather", (output_tensors, [input_tensor], AllgatherOptions())),
         ("broadcast", (tensor_list, BroadcastOptions())),
         ("broadcast_one", (input_tensor, 0)),
+        ("reduce_scatter", (output_tensors, [input_tensor], ReduceScatterOptions())),
     ]
     works: Dict[str, dist._Work] = {}
     for coll_str, args in collectives:


### PR DESCRIPTION
# What does this PR do?
Continuation of work for https://github.com/pytorch/torchft/issues/97.

This PR:
- Adds more collectives:
  - allreduce_coalesced
  - alltoall_base
  - barrier
  - reduce_scatter
  - send/recv
- Extends `process_group_test.py` to accommodate the above collectives

Note - the `process_group_test` adds several new tests, increasing the test time from 16s to 22s. Not sure how avoidable this is - a prior version of this PR took 36s!

# Concerns and possible follow up actions

## Missing ops in backends
Notably `allgather_into_tensor_coalesced` and `reduce_scatter_tensor_coalesced` were not added in this PR.  

It was part of the plan, but started seeing an error such as:
```
E       AttributeError: 'torch._C._distributed_c10d.ProcessGroupNCCL' object has no attribute 'allgather_into_tensor_coalesced'
```

This was confusing, but surely enough this is true, if we do `dir(pg)` we see:
```
['NCCLConfig', 'Options', '__class__', '__delattr__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '_add_ephemeral_timeout', '_allgather_base', '_end_coalescing', '_get_backend_name', '_get_sequence_number_for_group', '_group_end', '_group_start', '_is_initialized', '_pybind11_conduit_v1_', '_reduce_scatter_base', '_set_default_timeout', '_set_sequence_number_for_group', '_shutdown', '_start_coalescing', '_verify_work_timeout', 'abort', 'allgather', 'allgather_coalesced', 'allreduce', 'allreduce_coalesced', 'alltoall', 'alltoall_base', 'barrier', 'bound_device_id', 'broadcast', 'comm_split_count', 'deregister_mem_pool', 'eager_connect_single_device', 'gather', 'monitored_barrier', 'name', 'options', 'perform_nocolor_split', 'rank', 'recv', 'recv_anysource', 'reduce', 'reduce_scatter', 'register_mem_pool', 'scatter', 'send', 'size', 'supports_splitting', 'uid']
```

After some digging I realized it was because `ProcessGroupNCCL` (and other pg backends) inherit collectives that are defined [here](https://github.com/pytorch/pytorch/blob/e3839bd60365d97f2509671fd4d0f928af0f6ae1/torch/csrc/distributed/c10d/init.cpp#L2475), which does not include `allgather_into_tensor_coalesced` or `reduce_scatter_tensor_coalesced`. This is confusing since we know that e.g. `allgather_into_tensor_coalesced` [is implemented](https://github.com/pytorch/pytorch/blob/e3839bd60365d97f2509671fd4d0f928af0f6ae1/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L667-L670) for the `ProcessGroupNCCL` backend.

There are likely several possible resolutions for this, so will defer for now for a future decision.


