### PR TITLE
Enhances `process_group_test` 

### DIFF
--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -362,6 +362,7 @@ _COLLECTIVE_TO_FUNC: Dict[str, Callable[[ProcessGroup, int, torch.Tensor], None]
     "reduce_scatter": run_reduce_scatter_test,
     "send/recv": run_send_recv_test,
 }
+_ALL_COLLECTIVES: List[str] = list(_COLLECTIVE_TO_FUNC.keys())
 
 
 class ProcessGroupTest(TestCase):
@@ -785,16 +786,12 @@ class MultiPgBaseTest(TestCase):
 
 class GlooMultiPgTest(MultiPgBaseTest):
     BACKEND = "gloo"
-    WORLD_SIZE = 2
-    COLLECTIVES = [
-        "allreduce",
-        "allreduce_coalesced",
-        "allgather",
-        "barrier",
-        "broadcast",
-        "broadcast_one",
-        "send/recv",
+    WORLD_SIZE = 3
+    SKIP = [
+        "alltoall_base",
+        "reduce_scatter",
     ]
+    COLLECTIVES: List[str] = list(set(_ALL_COLLECTIVES) - set(SKIP))
 
     @parameterized.expand(COLLECTIVES)
     def test_collective(self, collective: str) -> None:
@@ -807,16 +804,12 @@ class GlooMultiPgTest(MultiPgBaseTest):
 
 class BabyGlooMultiPgTest(MultiPgBaseTest):
     BACKEND = "baby_gloo"
-    WORLD_SIZE = 2
-    COLLECTIVES = [
-        "allreduce",
-        "allreduce_coalesced",
-        "allgather",
-        "barrier",
-        "broadcast",
-        "broadcast_one",
-        "send/recv",
+    WORLD_SIZE = 3
+    SKIP = [
+        "alltoall_base",
+        "reduce_scatter",
     ]
+    COLLECTIVES: List[str] = list(set(_ALL_COLLECTIVES) - set(SKIP))
 
     @parameterized.expand(COLLECTIVES)
     def test_collective(self, collective: str) -> None:
@@ -833,19 +826,8 @@ class BabyGlooMultiPgTest(MultiPgBaseTest):
 class BabyNcclMultiPgTest(MultiPgBaseTest):
     BACKEND = "baby_nccl"
     WORLD_SIZE = 2
-    COLLECTIVES = [
-        "allreduce",
-        "allreduce_coalesced",
-        "allgather",
-        "alltoall_base",
-        "barrier",
-        "broadcast",
-        "broadcast_one",
-        "reduce_scatter",
-        "send/recv",
-    ]
 
-    @parameterized.expand(COLLECTIVES)
+    @parameterized.expand(_ALL_COLLECTIVES)
     def test_collective(self, collective: str) -> None:
         self._run_parallel(collective, device="cuda")
 
@@ -856,18 +838,7 @@ class BabyNcclMultiPgTest(MultiPgBaseTest):
 class BabyNcclResiliencyTest(MultiPgBaseTest):
     BACKEND = "baby_nccl"
     WORLD_SIZE = 3
-    COLLECTIVES = [
-        "allreduce",
-        "allreduce_coalesced",
-        "allgather",
-        "alltoall_base",
-        "barrier",
-        "broadcast",
-        "broadcast_one",
-        "reduce_scatter",
-        "send/recv",
-    ]
 
-    @parameterized.expand(COLLECTIVES)
+    @parameterized.expand(_ALL_COLLECTIVES)
     def test_collective_with_resiliency(self, collective: str) -> None:
         self._run_parallel(collective, device="cuda")

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -697,11 +697,7 @@ class MultiPgBaseTest(TestCase):
         for pg in cls.pg_pool:
             shutdown = getattr(pg, "shutdown", None)
             if shutdown is not None:
-                # shutdown may have been called during resiliency test, so ignore errors
-                try:
-                    shutdown()
-                except Exception:
-                    pass
+                shutdown()
         cls.executor.shutdown(wait=True)
         super().tearDownClass()
 
@@ -713,11 +709,11 @@ class MultiPgBaseTest(TestCase):
         instantiate Gloo, NCCL, or Baby versions, etc.
         """
         if backend == "gloo":
-            return ProcessGroupGloo(timeout=timedelta(seconds=5))
+            return ProcessGroupGloo(timeout=timedelta(seconds=2))
         elif backend == "nccl":
             return ProcessGroupNCCL()
         elif backend == "baby_gloo":
-            return ProcessGroupBabyGloo(timeout=timedelta(seconds=5))
+            return ProcessGroupBabyGloo(timeout=timedelta(seconds=2))
         elif backend == "baby_nccl":
             return ProcessGroupBabyNCCL(timeout=timedelta(seconds=5))
         else:
@@ -757,9 +753,6 @@ class MultiPgBaseTest(TestCase):
             t1 = torch.tensor([rank + 1], device=dev, dtype=torch.float32)
             # Simulate failure on the fault rank, but other ranks should still succeed.
             if rank == fault_rank:
-                shutdown = getattr(pg, "shutdown", None)
-                if shutdown is not None:
-                    shutdown()
                 return f"Rank{rank} crashed"
 
             try:

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -705,17 +705,16 @@ class MultiPgBaseTest(TestCase):
     def _create_pg(cls, backend: str) -> ProcessGroup:
         """
         Helper that creates a new ProcessGroup of the specified type.
-        We replicate the logic from the original test_* methods to decide how to
-        instantiate Gloo, NCCL, or Baby versions, etc.
+
+        NCCL groups aren't currently supported - we prefer to test
+        BabyNCCLGroups as they spin up their own subprocesses.
         """
         if backend == "gloo":
-            return ProcessGroupGloo(timeout=timedelta(seconds=2))
-        elif backend == "nccl":
-            return ProcessGroupNCCL()
+            return ProcessGroupGloo(timeout=timedelta(seconds=1))
         elif backend == "baby_gloo":
             return ProcessGroupBabyGloo(timeout=timedelta(seconds=2))
         elif backend == "baby_nccl":
-            return ProcessGroupBabyNCCL(timeout=timedelta(seconds=5))
+            return ProcessGroupBabyNCCL(timeout=timedelta(seconds=10))
         else:
             # fallback / dummy
             return ProcessGroupDummy(0, 1)

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -712,7 +712,7 @@ class MultiPgBaseTest(TestCase):
         if backend == "gloo":
             return ProcessGroupGloo(timeout=timedelta(seconds=1))
         elif backend == "baby_gloo":
-            return ProcessGroupBabyGloo(timeout=timedelta(seconds=2))
+            return ProcessGroupBabyGloo(timeout=timedelta(seconds=5))
         elif backend == "baby_nccl":
             return ProcessGroupBabyNCCL(timeout=timedelta(seconds=10))
         else:


### PR DESCRIPTION
See https://github.com/pytorch/torchft/issues/109 for more context, but there was a desire to:
1. Have collectives be tested on their own
2. Test true resiliency behaviors

# What does this PR do?
 - Removes `_test_multi_pg` and replaces it with individual `run_{collective}_test`s
 - Makes each `run_{collective}_test` robust to different world sizes (i.e. 1, 2, or 3) to be more generalizable
 - Introduces `MultiPgBaseTest`, a base test that spins up process groups and threadpool executors on setup (and destroys on teardown) so they can be re-used inbetween each test invocation. 
 - `MultiPgBaseTest` introduces:
   -  `_run_parallel`, a convenience function to run a collective test across its process groups, and
   - `_run_with_resiliency`, a convenience function that runs a collective test, invokes failure modes and tests for correct resiliency behaviors.
 - Removes all tests that utilized `_test_multi_pg` into `GlooMultiPgTest`, `BabyGlooMultiPgTest`, `BabyNcclMultiPgTest` and `BabyNcclResiliencyTest`
   - Note that `BabyNcclMultiPgTest` and `BabyNcclResiliencyTest` are separated so that the former can test for 2 GPUs, and the latter for 3. While all collectives could theoretically be tested with only 2 GPUs, it seems a bit trivial to run with only one process group.


Note that the test time increases from ~17s to ~43.48s:
```

==============================  60 passed in 43.48s ============================== 
```
mostly due to the resiliency tests taking awhile to run. Without the resiliency tests it takes 24.3 seconds:
```
$ pytest torchft/process_group_test.py -k "not resiliency"  && pkill -U $(whoami) py
thon
====================================== test session starts ======================================
platform linux -- Python 3.10.16, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/allencwang/workspace/torchft
configfile: pytest.ini
plugins: typeguard-2.13.3
collected 60 items / 23 deselected / 37 selected                                                

torchft/process_group_test.py .....................................                       [100%]

============================== 37 passed, 23 deselected in 24.29s ==============================
```

