### PR TITLE
Rename torchft to _torchft in project.scripts section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ features = ["pyo3/extension-module"]
 module-name = "torchft._torchft"
 
 [project.scripts]
-torchft_lighthouse = "torchft.torchft:lighthouse_main"
+torchft_lighthouse = "torchft._torchft:lighthouse_main"
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
Seems like #84 renamed the module but it was not updated in the `pyproject.toml`.

Got `ModuleNotFoundError: No module named 'torchft.torchft'`