### PR TITLE
Clean up local_sgd and diloco

### DIFF
--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -10,7 +10,7 @@ This module implements a fault tolerant version of LocalSGD and related methods.
 """
 import logging
 from types import TracebackType
-from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Type
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type
 
 import torch
 from torch import nn, optim
@@ -59,8 +59,6 @@ class LocalSGD:
         model: nn.Module,
         optimizer: optim.Optimizer,
         sync_every: int,
-        backup_device: Optional[torch.device] = None,
-        pin_memory: bool = True,
     ) -> None:
         """
         Args:
@@ -78,21 +76,8 @@ class LocalSGD:
         self._local_step = 0
         self._sync_every = sync_every
         assert sync_every >= 1, "sync_every must be greater than or equal to 1"
-        device = backup_device or torch.device("cpu")
-        self._backup_parameters: Dict[str, torch.Tensor] = {}
-        for name, p in self._model.named_parameters():
-            t = torch.empty(*tuple(p.shape), dtype=p.dtype, device=device)
-            if (
-                pin_memory
-                and t.device == torch.device("cpu")
-                and torch.cuda.is_available()
-            ):
-                t = t.pin_memory()
-            self._backup_parameters[name] = t
 
         self._hooks: List[RemovableHandle] = []
-        # Need to copy the parameters to the host to be safe if we are on the first step.
-        self._save_parameters()
 
     def __enter__(self) -> "LocalSGD":
         # Add optimizer hook which increments the local step counter and syncs if necessary
@@ -108,9 +93,6 @@ class LocalSGD:
         traceback: Optional[TracebackType],
     ) -> bool:
         # Handle any cleanup or error handling here
-        if exc_type is not None:
-            # If an exception occurred, restore parameters
-            self._restore_parameters()
         # Clean up hooks
         for hook in self._hooks:
             hook.remove()
@@ -118,20 +100,8 @@ class LocalSGD:
 
         return False  # Propagate exceptions
 
-    def _save_parameters(self) -> None:
-        with torch.no_grad():
-            # TODO: consider running copy on a separate stream
-            for name, p in self._model.named_parameters():
-                self._backup_parameters[name].copy_(p.data, non_blocking=True)
-
-    def _restore_parameters(self) -> None:
-        with torch.no_grad():
-            # TODO: consider running copy on a separate stream
-            for name, p in self._model.named_parameters():
-                p.data.copy_(self._backup_parameters[name], non_blocking=False)
-
     def _step_post_hook(
-        self, _optim: optim.Optimizer, _args: List[object], _kwargs: Dict[str, object]
+        self, _optim: optim.Optimizer, _args: Tuple[Any, ...], _kwargs: Dict[str, Any]
     ) -> None:
         """
         This hook is registered on the optimizer and is called after the optimizer step.
@@ -151,30 +121,31 @@ class LocalSGD:
     def _perform_sync(self) -> None:
         """
         Performs the synchronization of the model weights across the manager.
-        This method is intended to be overridden by subclasses to implement custom
-        synchronization logic.
         """
-        self._average()
+        averaged_parameters = self._average()
         if self._manager.should_commit():
-            self._save_parameters()
-        else:
-            # commit failed, restore from the backup parameters
-            self._restore_parameters()
+            # Update the model parameters with the averaged values
+            for param, avg_param in zip(self._model.parameters(), averaged_parameters):
+                param.data.copy_(avg_param)
 
-    def _average(self) -> None:
-        # TODO: do we need to broadcast buffers like DDP does?
-
+    def _average(self) -> list[torch.Tensor]:
+        """
+        Averages the model parameters across the manager and returns the averaged parameters.
+        """
         works = []
-
+        averaged_parameters = []
         for p in self._model.parameters():
-            # TODO: bucketize parameters
-            works.append(self._manager.allreduce(p.data.detach()))
-
+            # Create a new tensor to store the averaged parameter
+            p.data.grad = None
+            avg_param = p.data.clone()
+            works.append(self._manager.allreduce(avg_param))
+            averaged_parameters.append(avg_param)
         for work in works:
             work.wait()
+        return averaged_parameters
 
 
-class DiLoCo(LocalSGD):
+class DiLoCo:
     """
     DiLoCo is a subclass of LocalSGD that overrides the synchronization
     mechanism to average and synchronize the pseudogradients (delta of the previous global weight and current local weights).
@@ -197,27 +168,96 @@ class DiLoCo(LocalSGD):
                 "Using DiLoCo require synchronous quorum to be enabled. "
                 "Ensure that the manager is initialized with use_async_quorum=False"
             )
-        super().__init__(
-            manager, model, inner_optimizer, sync_every, backup_device, pin_memory
-        )
+        super().__init__()
+        self._manager = manager
+        self._model = model
+        self._local_optimizer = inner_optimizer
+        self._local_step = 0
+        self._sync_every = sync_every
+        assert sync_every >= 1, "sync_every must be greater than or equal to 1"
+        self._backup_device = backup_device
+        self._pin_memory = pin_memory
+
+        self._hooks: List[RemovableHandle] = []
         self._outer_optimizer = outer_optimizer
+        self.original_parameters: Dict[str, torch.Tensor] = {}
+        for name, p in self._model.named_parameters():
+            t = torch.empty(*tuple(p.shape), dtype=p.dtype, device=self._backup_device)
+            if (
+                self._pin_memory
+                and t.device == torch.device("cpu")
+                and torch.cuda.is_available()
+            ):
+                t = t.pin_memory()
+            self.original_parameters[name] = t
+
+        # Need to copy the parameters to the host to be safe if we are on the first step.
+        self._save_parameters()
+
+    def _save_parameters(self) -> None:
+        with torch.no_grad():
+            # TODO: consider running copy on a separate stream
+            for name, p in self._model.named_parameters():
+                self.original_parameters[name].copy_(p.data, non_blocking=True)
+
+    def _restore_parameters(self) -> None:
+        with torch.no_grad():
+            # TODO: consider running copy on a separate stream
+            for name, p in self._model.named_parameters():
+                p.data.copy_(self.original_parameters[name], non_blocking=False)
+
+    def __enter__(self) -> "DiLoCo":
+        # Add optimizer hook which increments the local step counter and syncs if necessary
+        self._hooks.append(
+            self._local_optimizer.register_step_post_hook(self._step_post_hook)
+        )
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
+        # Handle any cleanup or error handling here
+        # Clean up hooks
+        for hook in self._hooks:
+            hook.remove()
+        self._hooks.clear()
+
+        return False  # Propagate exceptions
+
+    def _step_post_hook(
+        self, _optim: optim.Optimizer, _args: Tuple[Any, ...], _kwargs: Dict[str, Any]
+    ) -> None:
+        """
+        This hook is registered on the optimizer and is called after the optimizer step.
+        """
+        self._local_step += 1
+        if self._local_step >= self._sync_every:
+            self.sync()
+
+    def sync(self) -> None:
+        """
+        Synchronizes and averages the model weights across the manager.
+        """
+        self._manager.start_quorum()
+        self._perform_sync()
+        self._local_step = 0
 
     def _perform_sync(self) -> None:
         """
         Overrides the sync method to calculate the pseugradient, average them across the manager group, and
         step using the outer optimizer.
         """
-
         # Set the .grad field of each parameter to its pseudogradient
         for name, p in self._model.named_parameters():
-            assert name in self._backup_parameters
-            pseudogradient = p.data - self._backup_parameters[name]
+            pseudogradient = p.data - self.original_parameters[name]
             p.grad = pseudogradient
 
         self._average_grads()
         # Restore the parameters back to the previous state
         self._restore_parameters()
-
         if self._manager.should_commit():
             # Use the outer optimizer to update the model parameters
             self._outer_optimizer.step()

--- a/torchft/local_sgd_integ_test.py
+++ b/torchft/local_sgd_integ_test.py
@@ -1,18 +1,22 @@
 import copy
 import logging
+import re
+import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
+from datetime import timedelta
 from typing import Any, Dict
 from unittest import TestCase
 
 import torch
+from parameterized import parameterized
 from torch import nn, optim
 
 from torchft._torchft import LighthouseServer
 from torchft.local_sgd import DiLoCo, LocalSGD
 from torchft.manager import Manager
 from torchft.manager_integ_test import FailureInjector, MyModel, Runner
-from torchft.process_group import ProcessGroupGloo
+from torchft.process_group import ProcessGroupGloo, ProcessGroupNCCL
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -20,6 +24,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 def local_sgd_train_loop(
     rank: int,
     store_port: int,
+    device: torch.device,
     runner: Runner,
 ) -> Dict[str, Dict[str, object]]:
     with ExitStack() as stack:
@@ -49,24 +54,24 @@ def local_sgd_train_loop(
             world_size=runner.world_size,
             lighthouse_addr=runner.lighthouse_address,
             port=19530 + runner.replica_id,
+            timeout=timedelta(seconds=10),
             # pyre-fixme[6]: Incompatible parameter type
             **runner.manager_args,
         )
         stack.callback(lambda: manager.shutdown(wait=False))
 
-        m: nn.Module = MyModel()
+        m: nn.Module = MyModel().to(device)
         optimizer: optim.Optimizer = optim.Adam(m.parameters())
         criterion = nn.CrossEntropyLoss()
 
-        with LocalSGD(manager, m, optimizer, sync_every=2):
+        with LocalSGD(manager, m, optimizer, sync_every=2) as local_sgd:
             while True:
-                inputs = torch.rand(2, 3)
-                labels = torch.randint(4, (2,))
+                inputs = torch.rand(2, 3).to(device)
+                labels = torch.randint(4, (2,)).to(device)
 
                 optimizer.zero_grad()
                 out = m(inputs)
                 loss = criterion(out, labels)
-
                 loss.backward()
 
                 optimizer.step()
@@ -78,18 +83,21 @@ def local_sgd_train_loop(
 
         # return state_dict so we can check consistency
         return state_dict()
+    return {}
 
 
 def diloco_train_loop(
     rank: int,
     store_port: int,
+    device: torch.device,
     runner: Runner,
 ) -> Dict[str, Dict[str, object]]:
     with ExitStack() as stack:
         # Declare the model and optimizers
-        m: nn.Module = MyModel()
+        m: nn.Module = MyModel(2, 3)
         model_state_dict: Dict[str, Any] = runner.train_loop_args["model_state_dict"]
         m.load_state_dict(model_state_dict)
+        m.to(device)
 
         # Setup optimizers
         inner_optimizer: optim.Optimizer = torch.optim.AdamW(
@@ -102,15 +110,14 @@ def diloco_train_loop(
         # pyre-ignore[53]
         def load_state_dict(state_dict: Dict[str, Dict[str, object]]) -> None:
             m.load_state_dict(state_dict["model"])
-            # TODO: make this cleaner so we don't have to save this
-            diloco._backup_parameters = state_dict["backup_params"]
+            diloco.original_parameters = state_dict["original_params"]
             inner_optimizer.load_state_dict(state_dict["inner_optim"])
             outer_optimizer.load_state_dict(state_dict["outer_optim"])
 
         def state_dict() -> Dict[str, Dict[str, object]]:  # pyre-ignore[53]
             return {
                 "model": m.state_dict(),
-                "backup_params": copy.deepcopy(diloco._backup_parameters),
+                "original_params": diloco.original_parameters,
                 "inner_optim": inner_optimizer.state_dict(),
                 "outer_optim": outer_optimizer.state_dict(),
             }
@@ -131,6 +138,7 @@ def diloco_train_loop(
             world_size=runner.world_size,
             lighthouse_addr=runner.lighthouse_address,
             port=19530 + runner.replica_id,
+            timeout=timedelta(seconds=10),
             # pyre-fixme[6]: Incompatible parameter type
             **runner.manager_args,
         )
@@ -139,20 +147,25 @@ def diloco_train_loop(
         criterion = nn.CrossEntropyLoss()
         all_state_dicts = {}
         with DiLoCo(
-            manager, m, inner_optimizer, outer_optimizer, sync_every=2
+            manager,
+            m,
+            inner_optimizer,
+            outer_optimizer,
+            backup_device=device,
+            sync_every=2,
         ) as diloco:
             while True:
-                inputs = torch.rand(2, 3)
-                labels = torch.randint(4, (2,))
+                batch_size = 1
+                inputs = m.get_rand_inputs(batch_size).to(device)
+                labels = m.get_rand_labels(batch_size).to(device)
 
                 out = m(inputs)
                 loss = criterion(out, labels)
 
                 inner_optimizer.zero_grad()
                 loss.backward()
+                all_state_dicts[str(manager.current_step())] = state_dict()
                 inner_optimizer.step()
-                manager_step_str = str(manager.current_step())
-                all_state_dicts[manager_step_str] = state_dict()
 
                 # after 4 model updates then break
                 if manager.current_step() >= 4:
@@ -162,10 +175,16 @@ def diloco_train_loop(
 
         # return state_dict so we can check consistency
         return all_state_dicts
+    return {}
 
 
-class ManagerIntegTest(TestCase):
-    def test_local_sgd_recovery(self) -> None:
+class LocalSGDIntegTest(TestCase):
+    @parameterized.expand(
+        [
+            (False,),
+        ]
+    )
+    def test_local_sgd_recovery(self, use_cuda: bool) -> None:
         lighthouse = LighthouseServer(
             bind="[::]:0",
             min_replicas=2,
@@ -184,9 +203,11 @@ class ManagerIntegTest(TestCase):
             ):
                 runner = Runner(
                     replica_id=replica_id,
+                    num_replicas=num_replicas,
                     lighthouse_address=lighthouse.address(),
                     failure_injector=failure_injector,
                     train_loop=local_sgd_train_loop,
+                    use_cuda=use_cuda,
                     manager_args={
                         "use_async_quorum": False,
                     },
@@ -208,54 +229,65 @@ class ManagerIntegTest(TestCase):
             # LocalSGD only guarantees that the model is consistent across
             # replicas but uses separate optimizer states.
             torch.testing.assert_close(
-                state_dict[0]["model"], state_dicts[0][0]["model"]
+                state_dict[0]["model"], state_dicts[0][0]["model"], check_device=False
             )
 
         self.assertEqual(failure_injectors[1].count, 1)
 
-    def test_diloco_healthy(self) -> None:
-        lighthouse = LighthouseServer(
-            bind="[::]:0",
-            min_replicas=2,
-        )
+    @parameterized.expand(
+        [
+            (False,),
+        ]
+    )
+    def test_diloco_healthy(self, use_cuda: bool) -> None:
+        lighthouse = LighthouseServer(bind="[::]:0", min_replicas=2)
         num_replicas = 2
         futures = []
 
         torch.manual_seed(42)
         # Initialize the model so we can pass in the state_dict
-        m: nn.Module = MyModel()
+        m: nn.Module = MyModel(2, 3)
 
         with ThreadPoolExecutor(max_workers=num_replicas) as executor:
             for replica_id in range(num_replicas):
                 failure_injector = FailureInjector()
                 runner = Runner(
                     replica_id=replica_id,
+                    num_replicas=num_replicas,
                     lighthouse_address=lighthouse.address(),
                     failure_injector=failure_injector,
                     train_loop=diloco_train_loop,
+                    use_cuda=use_cuda,
                     train_loop_args={
                         "model_state_dict": m.state_dict(),
                     },
                 )
                 futures.append(executor.submit(runner.run_replica))
 
-        state_dicts = []
-
-        for fut in as_completed(futures):
-            state_dicts.append(fut.result()[0])
+            state_dicts = []
+            for fut in as_completed(futures):
+                try:
+                    state_dicts.append(fut.result()[0])
+                except Exception as e:
+                    print(e, flush=True)
+                    traceback.print_exc()
+                    raise
 
         lighthouse.shutdown()
 
-        for replica_group in state_dicts:
-            for step, state_dict in replica_group.items():
-                # inner optimizer will be different, outer optimizer and model should be the same
-                torch.testing.assert_close(
-                    state_dict["backup_params"],
-                    state_dicts[0][str(step)]["backup_params"],
-                )
-                torch.testing.assert_close(
-                    state_dict["outer_optim"], state_dicts[0][str(step)]["outer_optim"]
-                )
+        rep0, rep1 = state_dicts
+        for step, state_dict in rep1.items():
+            # inner optimizer will be different, outer optimizer and model should be the same
+            torch.testing.assert_close(
+                state_dict["model"],
+                rep0[step]["model"],
+                check_device=False,
+            )
+            torch.testing.assert_close(
+                state_dict["outer_optim"],
+                rep0[step]["outer_optim"],
+                check_device=False,
+            )
 
     def test_diloco_recovery(self) -> None:
         lighthouse = LighthouseServer(
@@ -272,7 +304,7 @@ class ManagerIntegTest(TestCase):
 
         torch.manual_seed(42)
         # Initialize the model so we can pass in the state_dict
-        m: nn.Module = MyModel()
+        m: nn.Module = MyModel(2, 3)
 
         with ThreadPoolExecutor(max_workers=num_replicas) as executor:
             for replica_id, failure_injector in zip(
@@ -280,6 +312,7 @@ class ManagerIntegTest(TestCase):
             ):
                 runner = Runner(
                     replica_id=replica_id,
+                    num_replicas=num_replicas,
                     lighthouse_address=lighthouse.address(),
                     failure_injector=failure_injector,
                     train_loop=diloco_train_loop,
@@ -299,18 +332,19 @@ class ManagerIntegTest(TestCase):
                     raise
 
         lighthouse.shutdown()
-        for replica_group in state_dicts:
-            for step, state_dict in replica_group.items():
-                str_step = str(step)
-                if str_step in state_dicts[0]:
-                    # inner optimizer will be different, outer optimizer and model should be the same
-                    torch.testing.assert_close(
-                        state_dict["backup_params"],
-                        state_dicts[0][str_step]["backup_params"],
-                    )
-                    torch.testing.assert_close(
-                        state_dict["outer_optim"],
-                        state_dicts[0][str_step]["outer_optim"],
-                    )
 
+        rep0, rep1 = state_dicts
+
+        for step in rep0.keys():
+            # Inner optimizer will be different, outer optimizer and model should be the same
+            torch.testing.assert_close(
+                rep1[step]["model"],
+                rep0[step]["model"],
+                check_device=False,
+            )
+            torch.testing.assert_close(
+                rep1[step]["outer_optim"],
+                rep0[step]["outer_optim"],
+                check_device=False,
+            )
         self.assertEqual(failure_injectors[1].count, 1)


### PR DESCRIPTION
Changes:
- Remove backup parameters from local_sgd
- clean up tests
- Make DiLoCo not a subclass of local_sgd (there is some code repetition, but I think this is okay if we want to use these as an example for using our torchft APIs)