### PR TITLE
ProcessGroupNCCL: use _TimeoutManager to provide sane NCCL abort semantics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ Issues = "https://github.com/pytorch-labs/torchft/issues"
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-timeout",
     "black",
     "pyre-check",
     "parameterized",
@@ -41,3 +42,10 @@ torchft_lighthouse = "torchft._torchft:lighthouse_main"
 [tool.isort]
 multi_line_output = 3
 combine_as_imports = true
+
+[tool.pytest.ini_options]
+log_format = "%(asctime)s %(levelname)s %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"
+log_level = "INFO"
+timeout = 60
+timeout_method = "thread"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-log_format = %(asctime)s %(levelname)s %(message)s
-log_date_format = %Y-%m-%d %H:%M:%S
-log_level = INFO

--- a/torchft/futures.py
+++ b/torchft/futures.py
@@ -1,9 +1,11 @@
 import asyncio
 import threading
+from contextlib import contextmanager
 from datetime import timedelta
-from typing import Optional, TypeVar
+from typing import Callable, Generator, Optional, TypeVar
 from unittest.mock import Mock
 
+import torch
 from torch.futures import Future
 
 T = TypeVar("T")
@@ -12,20 +14,24 @@ T = TypeVar("T")
 class _TimerHandle:
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._lock.acquire()
         self._timer_handle: Optional[asyncio.TimerHandle] = None
+        self._cancelled = False
 
-    def set_timer(self, timer_handle: asyncio.TimerHandle) -> None:
-        assert self._lock.locked()
-
-        self._timer_handle = timer_handle
-        self._lock.release()
+    def set_timer_handle(self, timer_handle: asyncio.TimerHandle) -> None:
+        with self._lock:
+            if self._cancelled:
+                timer_handle.cancel()
+                self._timer_handle = None
+            else:
+                self._timer_handle = timer_handle
 
     def cancel(self) -> None:
         with self._lock:
-            assert self._timer_handle is not None
-            self._timer_handle.cancel()
-            self._timer_handle = None
+            assert not self._cancelled, "timer can only be cancelled once"
+            self._cancelled = True
+            if self._timer_handle is not None:
+                self._timer_handle.cancel()
+                self._timer_handle = None
 
 
 class _TimeoutManager:
@@ -81,8 +87,16 @@ class _TimeoutManager:
         # pyre-fixme[29]: Future is not a function
         timed_fut: Future[T] = Future()
         handle: _TimerHandle = _TimerHandle()
-        # pyre-fixme[6]: *args
-        loop.call_soon_threadsafe(self._register, loop, timed_fut, timeout, handle)
+        loop.call_soon_threadsafe(
+            self._register_callback,
+            loop,
+            lambda: timed_fut.set_exception(
+                # pyre-fixme[6]: e is not T
+                TimeoutError(f"future did not complete within {timeout}")
+            ),
+            timeout,
+            handle,
+        )
 
         def callback(fut: Future[T]) -> None:
             handle.cancel()
@@ -99,22 +113,48 @@ class _TimeoutManager:
         fut.add_done_callback(callback)
         return timed_fut
 
+    def stream_timeout(self, callback: Callable[[], None], timeout: timedelta) -> None:
+        loop = self._maybe_start_event_loop()
+
+        event: torch.cuda.Event = torch.cuda.Event()
+        event.record()
+
+        def handler() -> None:
+            if not event.query():
+                callback()
+
+        loop.call_soon_threadsafe(
+            self._register_callback, loop, handler, timeout, _TimerHandle()
+        )
+
     @classmethod
-    def _register(
+    def _register_callback(
         cls,
         loop: asyncio.AbstractEventLoop,
-        fut: Future[T],
+        callback: Callable[[], None],
         timeout: timedelta,
         handle: _TimerHandle,
     ) -> None:
         timer_handle = loop.call_later(
             timeout.total_seconds(),
-            lambda: fut.set_exception(
-                # pyre-fixme[6]: e is not T
-                TimeoutError(f"future did not complete within {timeout}")
-            ),
+            callback,
         )
-        handle.set_timer(timer_handle)
+        handle.set_timer_handle(timer_handle)
+
+    @contextmanager
+    def context_timeout(
+        self, callback: Callable[[], None], timeout: timedelta
+    ) -> Generator[None, None, None]:
+        loop = self._maybe_start_event_loop()
+        handle = _TimerHandle()
+
+        loop.call_soon_threadsafe(
+            self._register_callback, loop, callback, timeout, handle
+        )
+
+        yield
+
+        handle.cancel()
 
 
 _TIMEOUT_MANAGER = _TimeoutManager()
@@ -163,3 +203,35 @@ def future_wait(fut: Future[T], timeout: timedelta) -> T:
         raise TimeoutError(f"future did not complete within {timeout}")
 
     return fut.wait()
+
+
+def stream_timeout(callback: Callable[[], None], timeout: timedelta) -> None:
+    """
+    Registers a callback that will be called after the specified timeout if
+    the current stream doesn't complete in time.
+
+    This uses a cuda Event to track the completion of the current stream. If
+    the stream is not complete after the timeout, the callback is called.
+
+    Args:
+        callback: The callback to call if the stream doesn't complete in time.
+        timeout: The timeout to wait for the stream to complete.
+    """
+    _TIMEOUT_MANAGER.stream_timeout(callback, timeout)
+
+
+@contextmanager
+def context_timeout(
+    callback: Callable[[], None], timeout: timedelta
+) -> Generator[None, None, None]:
+    """
+    Registers a callback that will be called after the specified timeout if
+    the current contextmanager doesn't exit in time.
+
+    Args:
+        callback: The callback to call if we time out.
+        timeout: How long to wait for the contextmanager to exit.
+    """
+
+    with _TIMEOUT_MANAGER.context_timeout(callback, timeout):
+        yield

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -5,11 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import gc
-import io
-import multiprocessing
 import os
-import unittest
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import timedelta
 from typing import Any, Callable, Dict, List, cast
 from unittest import TestCase, skipUnless
@@ -33,7 +30,6 @@ from torch._C._distributed_c10d import (
 from torch.distributed import (
     ReduceOp,
     TCPStore,
-    Work,
     _functional_collectives,
     get_world_size,
 )
@@ -142,7 +138,6 @@ def _test_pg(
                 continue
             raise e
 
-    print(works)
     return works
 
 
@@ -323,10 +318,13 @@ def run_broadcast_one_test(pg: ProcessGroup, rank: int, tensor: torch.Tensor) ->
     )
 
 
-# pyre-fixme[2]: Parameter must be annotated.
-def run_barrier_test(pg: ProcessGroup, *args) -> None:
+def run_barrier_test(pg: ProcessGroup, rank: int, tensor: torch.Tensor) -> None:
     """Test barrier collective operation."""
-    barrier_work = pg.barrier(BarrierOptions())
+    opts = BarrierOptions()
+    if tensor.is_cuda:
+        device_id = tensor.device.index
+        opts.device_ids = [device_id]
+    barrier_work = pg.barrier(opts)
     barrier_work.wait()
 
 
@@ -856,20 +854,23 @@ class MultiPgBaseTest(TestCase):
         if backend == "gloo":
             return ProcessGroupGloo(timeout=timedelta(seconds=1))
         elif backend == "baby_gloo":
-            return ProcessGroupBabyGloo(timeout=timedelta(seconds=5))
+            return ProcessGroupBabyGloo(timeout=timedelta(seconds=10))
+        elif backend == "nccl":
+            return ProcessGroupNCCL(timeout=timedelta(seconds=1))
         elif backend == "baby_nccl":
             return ProcessGroupBabyNCCL(timeout=timedelta(seconds=10))
-        else:
-            # fallback / dummy
+        elif backend == "dummy":
             return ProcessGroupDummy(0, 1)
+        else:
+            raise NotImplementedError(f"Unsupported backend: {backend}")
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def _run_parallel(self, collective: str, device: str = "cpu") -> List[Any]:
+    def _run_parallel(self, collective: str, device: str = "cpu") -> None:
         """
         Helper to run on all ranks in parallel, returning a list
         of results or raising an exception if any fail.
         """
         func = _COLLECTIVE_TO_FUNC[collective]
+
         futures = []
         for rank in range(self.WORLD_SIZE):
             pg = self.pg_pool[rank]
@@ -879,9 +880,20 @@ class MultiPgBaseTest(TestCase):
             tensor = torch.tensor([rank + 1], device=device)
             fut = self.executor.submit(func, pg, rank, tensor)
             futures.append(fut)
-        return [f.result() for f in futures]
 
-    def _run_with_resiliency(self, collective: str, device: str = "cpu") -> List[str]:
+        self._collect(futures)
+
+    def _collect(self, futs: list[Future]) -> None:
+        for i, f in enumerate(futs):
+            try:
+                res = f.result()  # timeout=10)
+                if res:
+                    print(f"Rank {i}: {res}")
+            except Exception as e:
+                print(f"Rank {i}: {e}")
+                raise
+
+    def _run_with_resiliency(self, collective: str, device: str = "cpu") -> None:
         """
         Run a collective with resiliency:
         - fault_rank (last rank) simulates a crash.
@@ -890,28 +902,39 @@ class MultiPgBaseTest(TestCase):
         """
 
         def worker(pg: ProcessGroup, rank: int, dev: str) -> str:
+            if dev == "cuda":
+                torch.cuda.set_device(rank)
+
             fault_rank = self.WORLD_SIZE - 1
             test = _COLLECTIVE_TO_FUNC[collective]
 
-            t1 = torch.tensor([rank + 1], device=dev, dtype=torch.float32)
+            # Re-configure the PG to exclude the fault rank
+            new_store_addr = f"localhost:{self.store.port}/reconfig_{collective}"
+
+            pg.configure(new_store_addr, rank, self.WORLD_SIZE)
+
+            # run the same collective again successfully
+            t2 = torch.tensor([rank + 1], device=dev)
+            test(pg, rank, t2)
+
+            # Simulate a failure
+
+            t1 = torch.tensor([rank + 1], device=dev)
             # Simulate failure on the fault rank, but other ranks should still succeed.
             if rank == fault_rank:
                 pg.shutdown()
                 return f"Rank{rank} crashed"
 
-            try:
+            # We hardcode the list of expected errors.
+            # gloo: Connection closed by peer, timed out waiting, no error, read error
+            # nccl: Tensor-likes are not equal/not close (due to abort)
+            with self.assertRaisesRegex(
+                Exception,
+                r"(Connection closed by peer|Timed out waiting|no error|Read error|not equal|not close)",
+            ):
                 test(pg, rank, t1.clone())
-            except RuntimeError as e:
-                assert f"Simulated rank{rank} failure" in str(e)
+                raise RuntimeError("no error")
 
-            # Re-configure the PG to exclude the fault rank
-            new_world_size = self.WORLD_SIZE - 1
-            new_store_addr = f"localhost:{self.store.port}/reconfig_{collective}"
-            pg.configure(new_store_addr, rank, new_world_size)
-
-            # run the same collective again successfully
-            t2 = torch.tensor([rank + 1], device=dev, dtype=torch.float32)
-            test(pg, rank, t2)
             return f"Rank{rank} final success."
 
         # run in parallel
@@ -919,13 +942,7 @@ class MultiPgBaseTest(TestCase):
             self.executor.submit(worker, self.pg_pool[r], r, device)
             for r in range(self.WORLD_SIZE)
         ]
-        results = []
-        for f in futs:
-            try:
-                results.append(f.result(timeout=20))
-            except Exception as e:
-                results.append(e)
-        return results
+        self._collect(futs)
 
 
 class GlooMultiPgTest(MultiPgBaseTest):
@@ -942,6 +959,11 @@ class GlooMultiPgTest(MultiPgBaseTest):
     def test_collective(self, collective: str) -> None:
         self._run_parallel(collective, device="cpu")
 
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    @skipUnless(
+        torch.__version__ >= "2.7",
+        "torch 2.6 has a bug with destructing PyWork objects",
+    )
     @parameterized.expand(COLLECTIVES)
     def test_collective_with_resiliency(self, collective: str) -> None:
         self._run_with_resiliency(collective, device="cpu")
@@ -977,14 +999,25 @@ class BabyNcclMultiPgTest(MultiPgBaseTest):
     def test_collective(self, collective: str) -> None:
         self._run_parallel(collective, device="cuda")
 
+    # @parameterized.expand(_ALL_COLLECTIVES)
+    # def test_collective_with_resiliency(self, collective: str) -> None:
+    #    self._run_with_resiliency(collective, device="cuda")
+
 
 @skipUnless(
-    torch.cuda.is_available() and torch.cuda.device_count() >= 3, "needs 3 CUDA devices"
+    torch.cuda.is_available()
+    and torch.cuda.device_count() >= 2
+    and torch.cuda.nccl.version() >= (2, 25),
+    "needs 2 CUDA devices and NCCL >=2.25",
 )
-class BabyNcclResiliencyTest(MultiPgBaseTest):
-    BACKEND = "baby_nccl"
-    WORLD_SIZE = 3
+class NormalNcclMultiPgTest(MultiPgBaseTest):
+    BACKEND = "nccl"
+    WORLD_SIZE = 2
+
+    @parameterized.expand(_ALL_COLLECTIVES)
+    def test_collective(self, collective: str) -> None:
+        self._run_parallel(collective, device="cuda")
 
     @parameterized.expand(_ALL_COLLECTIVES)
     def test_collective_with_resiliency(self, collective: str) -> None:
-        self._run_parallel(collective, device="cuda")
+        self._run_with_resiliency(collective, device="cuda")


### PR DESCRIPTION
This disables normal ProcessGroupNCCL timeouts and instead uses `_TimeoutManager` to provide user space NCCL abort semantics using a background timer thread and a CUDA event to track completion.

Notable changes:
* Every time we wait on `ProcessGroupNCCL` collective we register an abort callback that fires if it doesn't complete in time.
* Long timeouts will result in many extra timeout entries that aren't cancelled since we don't proactively cleanup the timer events.
* This depends on NCCL aborting which is known to be buggy in `NCCL 2.25.1-1`
* We use `_opts_hook` and `_wrap_work` to ProcessGroupWrapper to provide wrappers around the base ProcessGroupNCCL to add in this logic.
* We always disable the timeout passed to base ProcessGroupNCCL to avoid watchdog/heartbeat from failing. We may also need to set other options on creation to avoid having background NCCL errors crash the process.

This also updates the `process_group_test.py` resiliency tests since they were broken and always returned success messages. It now guarantees that operations scheduled on a PG on error exit and don't block forever.

TODO: Figure out if we need to set these envs when we are also overriding the timeout

* TORCH_NCCL_RETHROW_CUDA_ERRORS=0
* TORCH_NCCL_DUMP_ON_TIMEOUT=0
* TORCH_NCCL_PROPAGATE_ERROR=0

Test plan:

```
pytest torchft/process_group_test.py
```

I haven't tested this E2E with torchtitan yet but that's next on the list.