### PR TITLE
ci: fix protobuf dep

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -35,7 +35,7 @@ jobs:
         set -ex
 
         # install python and protobuf
-        conda create -n venv python=3.12 protobuf -y
+        conda create -n venv python=3.12 libprotobuf -y
         conda activate venv
         python -m pip install --upgrade pip
 


### PR DESCRIPTION
This fixes CI by installing the correct protobuf library. The latest version of conda `protobuf` doesn't install `libprotobuf` which is what we actually need.

Test plan:

CI