### PR TITLE
ProcessGroupNCCL,Manager: surface async abort errors correctly

### DIFF
--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -445,6 +445,8 @@ class Manager:
         quorum_timeout: timedelta,
         curr_device: int,
     ) -> None:
+        torch.multiprocessing._set_thread_name("torchft_quorum")
+
         if curr_device >= 0 and torch.cuda.is_available():
             torch.cuda.set_device(curr_device)
         quorum = self._client._quorum(
@@ -604,6 +606,9 @@ class Manager:
             self._recovery_stream.synchronize()
 
         self._pending_work = []
+
+        if err := self._pg.errored():
+            self.report_error(err)
 
         # apply state_dict if healing
         if self._healing:


### PR DESCRIPTION
This adds a mechanism for propagating abort errors to Manager via `ProcessGroup.errored()`.

Without this change we don't wait for all operations to complete in `Manager.should_commit` and even if an abort occurs we don't detect it as they're running asynchronously on the GPU and NCCL abort causes it to return successfully.

This intentionally adds a synchronization point in `should_commit`.

This also includes a small fix in the resiliency tests to avoid stream dependencies between different worker threads.

Test plan:

```
pytest -o log_cli=1 torchft/process_group_test.py -v -s -x -k 'NormalNcclMultiPgTest'
pytest torchft/manager_test.py
```