### PR TITLE
Support generic quorum api on LighthouseClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ gethostname = "0.5.0"
 log = "0.4.22"
 prost = "0.13.3"
 prost-types = "0.13.3"
-pyo3 = {version = "0.22.3", features = ["extension-module"]}
+pyo3 = {version = "0.24", features = ["extension-module"]}
 rand = "0.8.5"
 slog = "2.7.0"
 slog-stdlog = "4.1.1"

--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -42,6 +42,7 @@ message QuorumMember {
     int64 step = 4;
     uint64 world_size = 5;
     bool shrink_only = 6;
+    // User passing in data stored as JSON string.
     string data = 7;
 }
 

--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -42,6 +42,7 @@ message QuorumMember {
     int64 step = 4;
     uint64 world_size = 5;
     bool shrink_only = 6;
+    string data = 7;
 }
 
 message Quorum {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,7 @@ async fn lighthouse_main_async(opt: lighthouse::LighthouseOpt) -> Result<()> {
     Ok(())
 }
 
+// struct used to pass data back to the python side
 #[pyclass(get_all, set_all)]
 pub struct PyQuorumMember {
     replica_id: String,
@@ -354,6 +355,7 @@ pub struct PyQuorumMember {
 }
 
 impl PyQuorumMember {
+    // PyDict has not implemeted Clone, so we need to implement it manually
     pub fn clone_with_py(&self, py: Python) -> Self {
         PyQuorumMember {
             replica_id: self.replica_id.clone(),
@@ -396,6 +398,7 @@ impl From<prost_types::Timestamp> for PyTimestamp {
     }
 }
 
+// Util functions to convert between python dict and rust string using json.
 fn pydict_to_string<'py>(py: Python, data: Option<&Bound<'_, PyDict>>) -> PyResult<String> {
     match data {
         Some(d) => {

--- a/src/lighthouse.rs
+++ b/src/lighthouse.rs
@@ -638,6 +638,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             },
         );
@@ -654,6 +655,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             },
         );
@@ -709,6 +711,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             },
         );
@@ -747,6 +750,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             },
         );
@@ -793,6 +797,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             },
         );
@@ -813,6 +818,7 @@ mod tests {
                 step: 1,
                 world_size: 1,
                 shrink_only: false,
+                data: String::new(),
             }],
             created: Some(SystemTime::now().into()),
         });
@@ -831,6 +837,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             },
         );
@@ -874,6 +881,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
                 QuorumMember {
                     replica_id: "b".to_string(),
@@ -882,6 +890,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             ],
             created: Some(SystemTime::now().into()),
@@ -898,6 +907,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: true,
+                    data: String::new(),
                 },
             },
         );
@@ -915,6 +925,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: true,
+                    data: String::new(),
                 },
             },
         );
@@ -963,6 +974,7 @@ mod tests {
                     step: 10,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 }),
             });
 
@@ -1008,6 +1020,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             },
         );
@@ -1033,6 +1046,7 @@ mod tests {
             step: 1,
             world_size: 1,
             shrink_only: false,
+            data: String::new(),
         }];
         let b = vec![QuorumMember {
             replica_id: "1".to_string(),
@@ -1041,6 +1055,7 @@ mod tests {
             step: 1000,
             world_size: 1,
             shrink_only: false,
+            data: String::new(),
         }];
 
         // replica_id is the same
@@ -1053,6 +1068,7 @@ mod tests {
             step: 1,
             world_size: 1,
             shrink_only: false,
+            data: String::new(),
         }];
         // replica_id changed
         assert!(quorum_changed(&a, &c));
@@ -1068,6 +1084,7 @@ mod tests {
                 step,
                 world_size: 1,
                 shrink_only,
+                data: String::new(),
             }
         }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -270,6 +270,7 @@ impl ManagerService for Arc<Manager> {
                     step: req.step,
                     world_size: self.world_size,
                     shrink_only: req.shrink_only,
+                    data: String::new(),
                 },
                 timeout,
             )
@@ -753,6 +754,7 @@ mod tests {
                     step: 0,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
                 QuorumMember {
                     replica_id: "replica_1".to_string(),
@@ -761,6 +763,7 @@ mod tests {
                     step: 0,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             ],
             created: None,
@@ -803,6 +806,7 @@ mod tests {
                     step: 0,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
                 QuorumMember {
                     replica_id: "replica_1".to_string(),
@@ -811,6 +815,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
                 QuorumMember {
                     replica_id: "replica_2".to_string(),
@@ -819,6 +824,7 @@ mod tests {
                     step: 0,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
                 QuorumMember {
                     replica_id: "replica_3".to_string(),
@@ -827,6 +833,7 @@ mod tests {
                     step: 1,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
                 QuorumMember {
                     replica_id: "replica_4".to_string(),
@@ -835,6 +842,7 @@ mod tests {
                     step: 0,
                     world_size: 1,
                     shrink_only: false,
+                    data: String::new(),
                 },
             ],
             created: None,

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -59,3 +59,21 @@ class LighthouseServer:
     ) -> None: ...
     def address(self) -> str: ...
     def shutdown(self) -> None: ...
+
+class LighthouseClient:
+    def __init__(
+        self,
+        addr: str,
+        connect_timeout: timedelta,
+    ) -> None: ...
+    def quorum(
+        self,
+        replica_id: str,
+        address: str,
+        store_address: str,
+        step: int,
+        world_size: int,
+        shrink_only: bool,
+        timeout: timedelta,
+        data: Optional[dict] = None,
+    ) -> object: ...

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import List, Optional
+from typing import Hashable, List, Optional
 
 class ManagerClient:
     def __init__(self, addr: str, connect_timeout: timedelta) -> None: ...
@@ -60,6 +61,27 @@ class LighthouseServer:
     def address(self) -> str: ...
     def shutdown(self) -> None: ...
 
+@dataclass
+class PyQuorumMember:
+    replica_id: str
+    address: str
+    store_address: str
+    step: int
+    world_size: int
+    shrink_only: bool
+    data: Optional[dict[Hashable, object]] = None
+
+@dataclass
+class PyTimestamp:
+    seconds: int
+    nanos: int
+
+@dataclass
+class PyQuorum:
+    quorum_id: str
+    participants: List[PyQuorumMember]
+    created: PyTimestamp
+
 class LighthouseClient:
     def __init__(
         self,
@@ -75,5 +97,5 @@ class LighthouseClient:
         world_size: int,
         shrink_only: bool,
         timeout: timedelta,
-        data: Optional[dict] = None,
-    ) -> object: ...
+        data: Optional[dict[Hashable, object]] = None,
+    ) -> "PyQuorum": ...

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -82,12 +82,11 @@ class Quorum:
     participants: List[QuorumMember]
     created: Timestamp
 
+@dataclass
 class LighthouseClient:
-    def __init__(
-        self,
-        addr: str,
-        connect_timeout: timedelta,
-    ) -> None: ...
+    addr: str
+    connect_timeout: timedelta
+
     def quorum(
         self,
         replica_id: str,
@@ -98,4 +97,4 @@ class LighthouseClient:
         shrink_only: bool,
         timeout: timedelta,
         data: Optional[dict[Hashable, object]] = None,
-    ) -> "Quorum": ...
+    ) -> Quorum: ...

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -62,7 +62,7 @@ class LighthouseServer:
     def shutdown(self) -> None: ...
 
 @dataclass
-class PyQuorumMember:
+class QuorumMember:
     replica_id: str
     address: str
     store_address: str
@@ -72,15 +72,15 @@ class PyQuorumMember:
     data: Optional[dict[Hashable, object]] = None
 
 @dataclass
-class PyTimestamp:
+class Timestamp:
     seconds: int
     nanos: int
 
 @dataclass
-class PyQuorum:
+class Quorum:
     quorum_id: str
-    participants: List[PyQuorumMember]
-    created: PyTimestamp
+    participants: List[QuorumMember]
+    created: Timestamp
 
 class LighthouseClient:
     def __init__(
@@ -98,4 +98,4 @@ class LighthouseClient:
         shrink_only: bool,
         timeout: timedelta,
         data: Optional[dict[Hashable, object]] = None,
-    ) -> "PyQuorum": ...
+    ) -> "Quorum": ...

--- a/torchft/coordination.py
+++ b/torchft/coordination.py
@@ -14,9 +14,15 @@ torchft.
 This provides direct access to the Lighthouse and Manager servers and clients.
 """
 
-from torchft._torchft import LighthouseServer, ManagerClient, ManagerServer
+from torchft._torchft import (
+    LighthouseClient,
+    LighthouseServer,
+    ManagerClient,
+    ManagerServer,
+)
 
 __all__ = [
+    "LighthouseClient",
     "LighthouseServer",
     "ManagerServer",
     "ManagerClient",

--- a/torchft/coordination.py
+++ b/torchft/coordination.py
@@ -19,6 +19,8 @@ from torchft._torchft import (
     LighthouseServer,
     ManagerClient,
     ManagerServer,
+    Quorum,
+    QuorumMember,
 )
 
 __all__ = [
@@ -26,4 +28,6 @@ __all__ = [
     "LighthouseServer",
     "ManagerServer",
     "ManagerClient",
+    "Quorum",
+    "QuorumMember",
 ]

--- a/torchft/coordination_test.py
+++ b/torchft/coordination_test.py
@@ -6,6 +6,8 @@ from torchft.coordination import (
     LighthouseServer,
     ManagerClient,
     ManagerServer,
+    Quorum,
+    QuorumMember,
 )
 
 
@@ -16,6 +18,8 @@ class TestCoordination(TestCase):
             ManagerServer,
             LighthouseServer,
             LighthouseClient,
+            Quorum,
+            QuorumMember,
         ]
         for cls in classes:
             self.assertIn("Args:", str(cls.__doc__), cls)

--- a/torchft/coordination_test.py
+++ b/torchft/coordination_test.py
@@ -1,7 +1,12 @@
 import inspect
 from unittest import TestCase
 
-from torchft.coordination import LighthouseServer, ManagerClient, ManagerServer
+from torchft.coordination import (
+    LighthouseClient,
+    LighthouseServer,
+    ManagerClient,
+    ManagerServer,
+)
 
 
 class TestCoordination(TestCase):
@@ -10,6 +15,7 @@ class TestCoordination(TestCase):
             ManagerClient,
             ManagerServer,
             LighthouseServer,
+            LighthouseClient,
         ]
         for cls in classes:
             self.assertIn("Args:", str(cls.__doc__), cls)

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -1,11 +1,11 @@
 import time
-from unittest import TestCase
 from datetime import timedelta
+from unittest import TestCase
 
 import torch.distributed as dist
 
 from torchft import Manager, ProcessGroupGloo
-from torchft._torchft import LighthouseServer, LighthouseClient
+from torchft._torchft import LighthouseClient, LighthouseServer
 
 
 class TestLighthouse(TestCase):
@@ -97,14 +97,15 @@ class TestLighthouse(TestCase):
                 world_size=1,
                 shrink_only=False,
                 timeout=timedelta(seconds=1),
-                data={"my_data": 1234}
+                data={"my_data": 1234},
             )
             assert result is not None
-            print(result)
             assert len(result.participants) == 1
             for member in result.participants:
                 assert member.replica_id == "lighthouse_test"
                 assert member.data is not None
+                assert "my_data" in member.data
+                assert member.data["my_data"] == 1234
 
         finally:
             # Cleanup

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import torch.distributed as dist
 
 from torchft import Manager, ProcessGroupGloo
-from torchft._torchft import LighthouseClient, LighthouseServer
+from torchft._torchft import LighthouseClient, LighthouseServer, Quorum, QuorumMember
 
 
 class TestLighthouse(TestCase):
@@ -100,8 +100,10 @@ class TestLighthouse(TestCase):
                 data={"my_data": 1234},
             )
             assert result is not None
+            assert isinstance(result, Quorum)
             assert len(result.participants) == 1
             for member in result.participants:
+                assert isinstance(member, QuorumMember)
                 assert member.replica_id == "lighthouse_test"
                 assert member.data is not None
                 assert "my_data" in member.data

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -1,6 +1,6 @@
-import re
 import time
 from unittest import TestCase
+from datetime import timedelta
 
 import torch.distributed as dist
 
@@ -81,7 +81,7 @@ class TestLighthouse(TestCase):
         try:
             client = LighthouseClient(
                 addr=lighthouse.address(),
-                connect_timeout=100,
+                connect_timeout=timedelta(seconds=1),
             )
             store = dist.TCPStore(
                 host_name="localhost",
@@ -92,16 +92,17 @@ class TestLighthouse(TestCase):
             result = client.quorum(
                 replica_id="lighthouse_test",
                 address="localhost",
-                store_addr="localhost",
+                store_address=f"localhost:{store.port}",
                 step=1,
                 world_size=1,
                 shrink_only=False,
-                timeout=100,
+                timeout=timedelta(seconds=1),
                 data={"my_data": 1234}
             )
             assert result is not None
-            assert len(result) == 1
-            for member in result:
+            print(result)
+            assert len(result.participants) == 1
+            for member in result.participants:
                 assert member.replica_id == "lighthouse_test"
                 assert member.data is not None
 


### PR DESCRIPTION
This is to address the issue here: https://github.com/pytorch/torchft/issues/140

generated doc:

<img width="901" alt="image" src="https://github.com/user-attachments/assets/18809adf-3e70-4649-a1c5-06a25a78d093" />

run the following test:
 pytest torchft/coordination_test.py
pytest torchft/lighthouse_test.py -k test_lighthouse_client_behavior
