### PR TITLE
Make params of quorum of lighthouse client optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ use crate::torchftpb::{
 };
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
-use pyo3::wrap_pyfunction;
 
 // Get the number of threads to use for the tokio runtime
 fn num_threads() -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,44 +501,38 @@ impl LighthouseClient {
     ///
     /// Args:
     ///     replica_id (str): The string id of the replica calling quorum.
-    ///     address (Optional[str]): The address of the replica calling quorum.
-    ///     store_address (Optional[str]): The address of the store.
-    ///     step (Optional[int]): The step of the replica calling quorum.
-    ///     world_size (Optional[int]): The world size of the replica calling quorum.
-    ///     shrink_only (Optional[bool]): Whether the quorum is for shrinking only.
-    ///     timeout (Optional[timedelta]): The timeout for quorum.
+    ///     timeout (timedelta): The timeout for quorum.
+    ///     address (str): The address of the replica calling quorum. Default: "".
+    ///     store_address (str): The address of the store. Default: "".
+    ///     step (int): The step of the replica calling quorum. Default: 0.
+    ///     world_size (int): The world size of the replica calling quorum. Default: 0.
+    ///     shrink_only (bool): Whether the quorum is for shrinking only. Default: false.
     ///     data (Optional[dict]): The data to be passed with quorum.
     ///
     /// Returns:
     ///     Quorum: Current quorum if successful.
     #[pyo3(signature = (
         replica_id,
-        address = None,
-        store_address = None,
-        step = None,
-        world_size = None,
-        shrink_only = None,
-        timeout = None,
+        timeout,
+        address = "".to_string(),
+        store_address = "".to_string(),
+        step = 0,
+        world_size = 0,
+        shrink_only = false,
         data = None
     ))]
     fn quorum<'py>(
         &self,
         py: Python<'_>,
         replica_id: String,
-        address: Option<String>,
-        store_address: Option<String>,
-        step: Option<i64>,
-        world_size: Option<u64>,
-        shrink_only: Option<bool>,
-        timeout: Option<Duration>,
+        timeout: Duration,
+        address: String,
+        store_address: String,
+        step: i64,
+        world_size: u64,
+        shrink_only: bool,
         data: Option<&Bound<'_, PyDict>>,
     ) -> Result<Quorum, StatusError> {
-        let address = address.unwrap_or("localhost".to_string());
-        let store_address = store_address.unwrap_or("localhost".to_string());
-        let step = step.unwrap_or(0);
-        let world_size = world_size.unwrap_or(0);
-        let timeout = timeout.unwrap_or(Duration::from_millis(1000));
-        let shrink_only = shrink_only.unwrap_or(false);
         let data_string = pydict_to_string(py, data)?;
         let quorum: Result<torchftpb::Quorum, StatusError> = py.allow_threads(move || {
             let mut request = tonic::Request::new(LighthouseQuorumRequest {

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -90,11 +90,11 @@ class LighthouseClient:
     def quorum(
         self,
         replica_id: str,
-        address: str,
-        store_address: str,
-        step: int,
-        world_size: int,
-        shrink_only: bool,
-        timeout: timedelta,
+        address: Optional[str] = None,
+        store_address: Optional[str] = None,
+        step: Optional[int] = None,
+        world_size: Optional[int] = None,
+        shrink_only: Optional[bool] = None,
+        timeout: Optional[timedelta] = None,
         data: Optional[dict[Hashable, object]] = None,
     ) -> Quorum: ...

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -90,11 +90,11 @@ class LighthouseClient:
     def quorum(
         self,
         replica_id: str,
+        timeout: timedelta,
         address: Optional[str] = None,
         store_address: Optional[str] = None,
         step: Optional[int] = None,
         world_size: Optional[int] = None,
         shrink_only: Optional[bool] = None,
-        timeout: Optional[timedelta] = None,
         data: Optional[dict[Hashable, object]] = None,
     ) -> Quorum: ...

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -112,6 +112,7 @@ class TestLighthouse(TestCase):
             # Test the optional args
             result = client.quorum(
                 replica_id="lighthouse_test",
+                timeout=timedelta(seconds=1),
             )
             assert result is not None
             for member in result.participants:

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -109,6 +109,14 @@ class TestLighthouse(TestCase):
                 assert "my_data" in member.data
                 assert member.data["my_data"] == 1234
 
+            # Test the optional args
+            result = client.quorum(
+                replica_id="lighthouse_test",
+            )
+            assert result is not None
+            for member in result.participants:
+                assert member.replica_id == "lighthouse_test"
+
         finally:
             # Cleanup
             lighthouse.shutdown()


### PR DESCRIPTION
Address the comment in https://github.com/pytorch/torchft/pull/150/files#r2015127529 to make the input params of quorum optional.