### PR TITLE
ManagedDeviceMesh: support TP

### DIFF
--- a/torchft/fsdp_test.py
+++ b/torchft/fsdp_test.py
@@ -30,17 +30,34 @@ from torch.distributed import (
 )
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    PrepareModuleInput,
+    RowwiseParallel,
+    SequenceParallel,
+    parallelize_module,
+)
 
 from torchft.manager import Manager
-from torchft.process_group import ManagedProcessGroup, ft_init_device_mesh
+from torchft.process_group import (
+    ManagedProcessGroup,
+    ProcessGroupGloo,
+    ft_init_device_mesh,
+)
 
 
 class FSDPTest(unittest.TestCase):
     @staticmethod
-    def _test_fsdp(world_size: int, rank: int) -> None:
+    def _test_fsdp(
+        world_size: int,
+        rank: int,
+        dp_replicate: int = 2,
+        dp_shard: int = 2,
+        tp: int = 1,
+    ) -> None:
         torch.cuda.set_device(rank)
 
-        group_size = world_size // 2
+        group_size = world_size // dp_replicate
         group = rank // group_size
         group_rank = rank % group_size
 
@@ -50,17 +67,28 @@ class FSDPTest(unittest.TestCase):
         os.environ["WORLD_SIZE"] = str(group_size)
 
         manager = Mock(spec=Manager)
+        manager._pg = ProcessGroupGloo()
         device_mesh = ft_init_device_mesh(
             device_type="cuda",
-            mesh_shape=(2, 2),
-            mesh_dim_names=("dp_replicate", "dp_shard"),
+            mesh_shape=(dp_replicate, dp_shard, tp),
+            mesh_dim_names=("dp_replicate", "dp_shard", "tp"),
             replicate_dim=0,
             manager=manager,
         )
         manager.num_participants.return_value = 1
         model = nn.Linear(128, 128).cuda()
         batch = torch.randn(4, 128).cuda()
-        shard_model = fully_shard(model, mesh=device_mesh)
+
+        fsdp_mesh = device_mesh["dp_replicate", "dp_shard"]
+
+        if tp > 1:
+            tp_mesh = device_mesh["tp"]
+            model = parallelize_module(
+                model,
+                tp_mesh,
+                ColwiseParallel(),
+            )
+        shard_model = fully_shard(model, mesh=fsdp_mesh)
         shard_model(batch).mean().backward()
 
     # pyre-ignore[56]: Pyre was not able to infer the type of argument
@@ -72,3 +100,21 @@ class FSDPTest(unittest.TestCase):
             for i in range(4):
                 future = executor.submit(self._test_fsdp, 4, i)
                 futures.append(future)
+
+            for fut in futures:
+                fut.result()
+
+    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(torch.cuda.device_count() < 4, "Not enough GPUs")
+    def test_fsdp_tp(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(max_workers=4, mp_context=context) as executor:
+            futures = []
+            for i in range(4):
+                future = executor.submit(
+                    self._test_fsdp, 4, i, dp_replicate=1, dp_shard=2, tp=2
+                )
+                futures.append(future)
+
+            for fut in futures:
+                fut.result()


### PR DESCRIPTION
FSDP+TP requires `_mesh_resources.get_root_mesh` support. This adds root information to `_mesh_resources` for the ManagedDeviceMesh as well as a few other fixes (`__repr__` and `__hash__`).

https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_fully_shard/_fsdp_param.py#L291