### PR TITLE
manager: Add option to skip initial sync

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -76,7 +76,7 @@ message ManagerQuorumRequest {
     int64 step = 2;
     string checkpoint_metadata = 3;
     bool shrink_only = 4;
-    optional bool init_sync = 5;
+    bool init_sync = 5;
 }
 
 message ManagerQuorumResponse {

--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -76,6 +76,7 @@ message ManagerQuorumRequest {
     int64 step = 2;
     string checkpoint_metadata = 3;
     bool shrink_only = 4;
+    optional bool init_sync = 5;
 }
 
 message ManagerQuorumResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ impl ManagerClient {
                 step: step,
                 checkpoint_metadata: checkpoint_metadata,
                 shrink_only: shrink_only,
+                init_sync: Some(false),
             });
 
             // This timeout is processed on the server side so we also enable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ impl ManagerClient {
         step: i64,
         checkpoint_metadata: String,
         shrink_only: bool,
+        init_sync: bool,
         timeout: Duration,
     ) -> Result<QuorumResult, StatusError> {
         py.allow_threads(move || {
@@ -183,7 +184,7 @@ impl ManagerClient {
                 step: step,
                 checkpoint_metadata: checkpoint_metadata,
                 shrink_only: shrink_only,
-                init_sync: true,
+                init_sync: init_sync,
             });
 
             // This timeout is processed on the server side so we also enable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ impl ManagerClient {
                 step: step,
                 checkpoint_metadata: checkpoint_metadata,
                 shrink_only: shrink_only,
-                init_sync: Some(false),
+                init_sync: true,
             });
 
             // This timeout is processed on the server side so we also enable

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -431,7 +431,10 @@ fn compute_quorum_results(
         .iter()
         .enumerate()
         .filter_map(|(i, p)| {
-            if p.step != max_step || max_step == 0 && primary.replica_id != p.replica_id {
+            if init_sync
+                || p.step != max_step
+                || max_step == 0 && primary.replica_id != p.replica_id
+            {
                 Some(i)
             } else {
                 None

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -888,4 +888,86 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_compute_quorum_results_skip_init_sync() -> Result<()> {
+        let quorum = Quorum {
+            quorum_id: 1,
+            participants: vec![
+                QuorumMember {
+                    replica_id: "replica_0".to_string(),
+                    address: "addr_0".to_string(),
+                    store_address: "store_addr_0".to_string(),
+                    step: 0,
+                    world_size: 1,
+                    shrink_only: false,
+                },
+                QuorumMember {
+                    replica_id: "replica_1".to_string(),
+                    address: "addr_1".to_string(),
+                    store_address: "store_addr_1".to_string(),
+                    step: 1,
+                    world_size: 1,
+                    shrink_only: false,
+                },
+                QuorumMember {
+                    replica_id: "replica_2".to_string(),
+                    address: "addr_2".to_string(),
+                    store_address: "store_addr_2".to_string(),
+                    step: 0,
+                    world_size: 1,
+                    shrink_only: false,
+                },
+                QuorumMember {
+                    replica_id: "replica_3".to_string(),
+                    address: "addr_3".to_string(),
+                    store_address: "store_addr_3".to_string(),
+                    step: 1,
+                    world_size: 1,
+                    shrink_only: false,
+                },
+                QuorumMember {
+                    replica_id: "replica_4".to_string(),
+                    address: "addr_4".to_string(),
+                    store_address: "store_addr_4".to_string(),
+                    step: 0,
+                    world_size: 1,
+                    shrink_only: false,
+                },
+            ],
+            created: None,
+        };
+
+        // rank 0
+
+        let results = compute_quorum_results("replica_0", 0, &quorum, false)?;
+        assert!(!results.heal);
+        assert_eq!(results.recover_src_manager_address, "".to_string());
+        assert_eq!(results.replica_rank, 0);
+        assert_eq!(results.recover_src_rank, None);
+        assert!(results.recover_dst_ranks.is_empty());
+
+        let results = compute_quorum_results("replica_1", 0, &quorum, false)?;
+        assert!(!results.heal);
+        assert_eq!(results.recover_src_manager_address, "".to_string());
+        assert_eq!(results.replica_rank, 1);
+        assert_eq!(results.recover_src_rank, None);
+        assert!(results.recover_dst_ranks.is_empty());
+
+        let results = compute_quorum_results("replica_3", 0, &quorum, false)?;
+        assert!(!results.heal);
+        assert_eq!(results.recover_src_manager_address, "".to_string());
+        assert_eq!(results.replica_rank, 3);
+        assert_eq!(results.recover_src_rank, None);
+        assert!(results.recover_dst_ranks.is_empty());
+
+        let results = compute_quorum_results("replica_1", 1, &quorum, false)?;
+        assert!(!results.heal);
+        assert_eq!(results.recover_src_manager_address, "".to_string());
+        assert_eq!(results.replica_rank, 1);
+        assert_eq!(results.recover_src_rank, None);
+        assert!(results.recover_dst_ranks.is_empty());
+
+        Ok(())
+    }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -286,12 +286,7 @@ impl ManagerService for Arc<Manager> {
 
         info_with_replica!(self.replica_id, "Finished quorum for rank {}", rank);
 
-        let reply = compute_quorum_results(
-            &self.replica_id,
-            rank,
-            &quorum,
-            req.init_sync.unwrap_or_default(),
-        )?;
+        let reply = compute_quorum_results(&self.replica_id, rank, &quorum, req.init_sync)?;
 
         Ok(Response::new(reply))
     }
@@ -430,23 +425,25 @@ fn compute_quorum_results(
 
     // Compute recovery assignments
 
-    // Nodes are recovering if:
-    // 1. not at the max step
-    // 2. max_step == 0 and not the primary replica
-    let all_recover_dst_ranks: Vec<usize> = participants
-        .iter()
-        .enumerate()
-        .filter_map(|(i, p)| {
-            if init_sync
-                || p.step != max_step
-                || max_step == 0 && primary.replica_id != p.replica_id
-            {
-                Some(i)
-            } else {
-                None
-            }
-        })
-        .collect();
+    let all_recover_dst_ranks = if init_sync {
+        // Nodes are recovering if
+        // 1. not at the max step
+        // 2. max_step == 0 and not the primary replica
+        participants
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| {
+                if p.step != max_step || max_step == 0 && primary.replica_id != p.replica_id {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        Vec::<usize>::new()
+    };
+
     let all_recover_dst_ranks_set = all_recover_dst_ranks.iter().collect::<HashSet<_>>();
     let up_to_date_ranks: Vec<usize> = participants
         .iter()
@@ -614,7 +611,7 @@ mod tests {
             step: 123,
             checkpoint_metadata: "addr".to_string(),
             shrink_only: false,
-            init_sync: Some(false),
+            init_sync: true,
         });
         request.set_timeout(Duration::from_secs(10));
         let resp = client.quorum(request).await?.into_inner();
@@ -674,7 +671,7 @@ mod tests {
                     step: 0,
                     checkpoint_metadata: "addr".to_string(),
                     shrink_only: false,
-                    init_sync: Some(false),
+                    init_sync: true,
                 });
                 request.set_timeout(Duration::from_secs(10));
 
@@ -782,13 +779,13 @@ mod tests {
 
         // rank 0
 
-        let results = compute_quorum_results("replica_0", 0, &quorum, false)?;
+        let results = compute_quorum_results("replica_0", 0, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 0);
         assert_eq!(results.recover_src_rank, None);
         assert_eq!(results.recover_dst_ranks, vec![1]);
 
-        let results = compute_quorum_results("replica_1", 0, &quorum, false)?;
+        let results = compute_quorum_results("replica_1", 0, &quorum, true)?;
         assert!(results.heal);
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, Some(0));
@@ -796,7 +793,7 @@ mod tests {
 
         // rank 1 assignments should be offset from rank 0 above and the primary
 
-        let results = compute_quorum_results("replica_1", 1, &quorum, false)?;
+        let results = compute_quorum_results("replica_1", 1, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, None);
@@ -861,21 +858,21 @@ mod tests {
 
         // rank 0
 
-        let results = compute_quorum_results("replica_0", 0, &quorum, false)?;
+        let results = compute_quorum_results("replica_0", 0, &quorum, true)?;
         assert!(results.heal);
         assert_eq!(results.recover_src_manager_address, "addr_1".to_string());
         assert_eq!(results.replica_rank, 0);
         assert_eq!(results.recover_src_rank, Some(1));
         assert!(results.recover_dst_ranks.is_empty());
 
-        let results = compute_quorum_results("replica_1", 0, &quorum, false)?;
+        let results = compute_quorum_results("replica_1", 0, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.recover_src_manager_address, "".to_string());
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, None);
         assert_eq!(results.recover_dst_ranks, vec![0, 4]);
 
-        let results = compute_quorum_results("replica_3", 0, &quorum, false)?;
+        let results = compute_quorum_results("replica_3", 0, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 3);
         assert_eq!(results.recover_src_rank, None);
@@ -883,7 +880,7 @@ mod tests {
 
         // rank 1 assignments should be offset from rank 0 above
 
-        let results = compute_quorum_results("replica_1", 1, &quorum, false)?;
+        let results = compute_quorum_results("replica_1", 1, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, None);

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -286,7 +286,12 @@ impl ManagerService for Arc<Manager> {
 
         info_with_replica!(self.replica_id, "Finished quorum for rank {}", rank);
 
-        let reply = compute_quorum_results(&self.replica_id, rank, &quorum)?;
+        let reply = compute_quorum_results(
+            &self.replica_id,
+            rank,
+            &quorum,
+            req.init_sync.unwrap_or_default(),
+        )?;
 
         Ok(Response::new(reply))
     }
@@ -382,6 +387,7 @@ fn compute_quorum_results(
     replica_id: &str,
     rank: i64,
     quorum: &Quorum,
+    init_sync: bool,
 ) -> Result<ManagerQuorumResponse, Status> {
     let mut participants = quorum.participants.clone();
     participants.sort_by(|a, b| a.replica_id.cmp(&b.replica_id));
@@ -608,6 +614,7 @@ mod tests {
             step: 123,
             checkpoint_metadata: "addr".to_string(),
             shrink_only: false,
+            init_sync: Some(false),
         });
         request.set_timeout(Duration::from_secs(10));
         let resp = client.quorum(request).await?.into_inner();
@@ -667,6 +674,7 @@ mod tests {
                     step: 0,
                     checkpoint_metadata: "addr".to_string(),
                     shrink_only: false,
+                    init_sync: Some(false),
                 });
                 request.set_timeout(Duration::from_secs(10));
 
@@ -774,13 +782,13 @@ mod tests {
 
         // rank 0
 
-        let results = compute_quorum_results("replica_0", 0, &quorum)?;
+        let results = compute_quorum_results("replica_0", 0, &quorum, false)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 0);
         assert_eq!(results.recover_src_rank, None);
         assert_eq!(results.recover_dst_ranks, vec![1]);
 
-        let results = compute_quorum_results("replica_1", 0, &quorum)?;
+        let results = compute_quorum_results("replica_1", 0, &quorum, false)?;
         assert!(results.heal);
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, Some(0));
@@ -788,7 +796,7 @@ mod tests {
 
         // rank 1 assignments should be offset from rank 0 above and the primary
 
-        let results = compute_quorum_results("replica_1", 1, &quorum)?;
+        let results = compute_quorum_results("replica_1", 1, &quorum, false)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, None);
@@ -853,21 +861,21 @@ mod tests {
 
         // rank 0
 
-        let results = compute_quorum_results("replica_0", 0, &quorum)?;
+        let results = compute_quorum_results("replica_0", 0, &quorum, false)?;
         assert!(results.heal);
         assert_eq!(results.recover_src_manager_address, "addr_1".to_string());
         assert_eq!(results.replica_rank, 0);
         assert_eq!(results.recover_src_rank, Some(1));
         assert!(results.recover_dst_ranks.is_empty());
 
-        let results = compute_quorum_results("replica_1", 0, &quorum)?;
+        let results = compute_quorum_results("replica_1", 0, &quorum, false)?;
         assert!(!results.heal);
         assert_eq!(results.recover_src_manager_address, "".to_string());
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, None);
         assert_eq!(results.recover_dst_ranks, vec![0, 4]);
 
-        let results = compute_quorum_results("replica_3", 0, &quorum)?;
+        let results = compute_quorum_results("replica_3", 0, &quorum, false)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 3);
         assert_eq!(results.recover_src_rank, None);
@@ -875,7 +883,7 @@ mod tests {
 
         // rank 1 assignments should be offset from rank 0 above
 
-        let results = compute_quorum_results("replica_1", 1, &quorum)?;
+        let results = compute_quorum_results("replica_1", 1, &quorum, false)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_rank, None);

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -11,7 +11,7 @@ class ManagerClient:
         checkpoint_metadata: str,
         shrink_only: bool,
         timeout: timedelta,
-        init_sync: Optional[bool] = False,
+        init_sync: bool = True,
     ) -> QuorumResult: ...
     def _checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
     def should_commit(

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -11,6 +11,7 @@ class ManagerClient:
         checkpoint_metadata: str,
         shrink_only: bool,
         timeout: timedelta,
+        init_sync: Optional[bool] = False,
     ) -> QuorumResult: ...
     def _checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
     def should_commit(

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -34,7 +34,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, cast, Dict, List, Optional, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypeVar, cast
 
 import torch
 from torch.distributed import ReduceOp, TCPStore
@@ -106,6 +106,7 @@ class Manager:
         hostname: str = socket.gethostname(),
         heartbeat_interval: timedelta = timedelta(milliseconds=100),
         checkpoint_transport: Optional[CheckpointTransport[Dict[str, T]]] = None,
+        init_sync: bool = True,
     ) -> None:
         """
         Args:
@@ -143,6 +144,9 @@ class Manager:
             hostname: if rank==0, the hostname to advertise to the lighthouse server
             checkpoint_transport: the checkpoint transport to use for
                 transfering checkpoints to recovering replicas, defaults to HTTPTransport
+            init_sync: whether to synchronize the model weights on step 0. If
+                all of the model weights are initialized identically via
+                ``torch.set_seed`` you should set this to False.
         """
         self._load_state_dict = load_state_dict
         self._user_state_dict = state_dict
@@ -152,6 +156,7 @@ class Manager:
         self._quorum_timeout = quorum_timeout
         self._connect_timeout = connect_timeout
         self._world_size_mode = world_size_mode
+        self._init_sync = init_sync
 
         store_addr = store_addr or os.environ["MASTER_ADDR"]
         store_port = store_port or int(os.environ["MASTER_PORT"])
@@ -455,7 +460,7 @@ class Manager:
             checkpoint_metadata=self._checkpoint_transport.metadata(),
             shrink_only=shrink_only,
             timeout=quorum_timeout,
-            init_sync=self.init_sync,
+            init_sync=self._init_sync,
         )
 
         quorum_id = quorum.quorum_id

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -34,7 +34,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from datetime import timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, TypeVar, cast
+from typing import Callable, cast, Dict, List, Optional, TYPE_CHECKING, TypeVar
 
 import torch
 from torch.distributed import ReduceOp, TCPStore
@@ -455,6 +455,7 @@ class Manager:
             checkpoint_metadata=self._checkpoint_transport.metadata(),
             shrink_only=shrink_only,
             timeout=quorum_timeout,
+            init_sync=self.init_sync,
         )
 
         quorum_id = quorum.quorum_id


### PR DESCRIPTION
This is a version of https://github.com/pytorch/torchft/pull/127 with a few fixes to support init_sync.

Fixes https://github.com/pytorch/torchft/issues/117

Test plan:

```
cargo test
pytest torchft/manager_test.py
pytest torchft/manager_integ_test.py

```