### PR TITLE
ci: use torch 2.7 RC builds

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,6 +23,9 @@ jobs:
 
           sudo apt-get install -y protobuf-compiler
 
+          # use RC build
+          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu128
+
           pip install lintrunner lintrunner-adapters
           lintrunner init
 

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -15,11 +15,11 @@ jobs:
           - runs-on: "linux.2xlarge"
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
-            torch-version: "stable"
+            torch-version: "test"
           - runs-on: "linux.g5.12xlarge.nvidia.gpu"
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
-            torch-version: "stable"
+            torch-version: "test"
           - runs-on: "linux.g5.12xlarge.nvidia.gpu"
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
@@ -46,6 +46,9 @@ jobs:
         # Optionally install torch nightly, pulls latest CUDA from pip otherwise
         if [ "${{ matrix.torch-version }}" = "nightly" ]; then
           pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+        fi
+        if [ "${{ matrix.torch-version }}" = "test" ]; then
+          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu128
         fi
 
         # Install dependencies

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Before proceeding, ensure you have the following installed:
 
 - Rust (with necessary dependencies)
 - `protobuf-compiler` and the corresponding development package for Protobuf.
+- PyTorch 2.7 RC+ or Nightly
 
 Note that the Rust versions available in many conda environments may be outdated. To install the latest version of Rust, we recommend downloading it directly from the official website as shown in the below command:
 ```sh

--- a/torchft/checkpointing/_serialization.py
+++ b/torchft/checkpointing/_serialization.py
@@ -26,7 +26,7 @@ def _fallback_load(f: IO[bytes], weights_only: bool = True) -> object:
 
 
 try:
-    # pyre-fixme[21]: upgrade to PT 2.7 once released
+    # upgrade to PT 2.7 once released
     from torch.distributed._serialization import _streaming_load, _streaming_save
 except ImportError:
     _streaming_load = _fallback_load

--- a/torchft/checkpointing/pg_transport.py
+++ b/torchft/checkpointing/pg_transport.py
@@ -290,7 +290,6 @@ class PGTransport(CheckpointTransport[T]):
                 values.append(recv(path, v))
             elif isinstance(v, _DTensorMeta):
                 tensor = recv(path, v.local)
-                # pyre-fixme[29]: DTensor is not a function
                 values.append(DTensor(tensor, v.spec, requires_grad=False))
             else:
                 values.append(v)

--- a/torchft/optim.py
+++ b/torchft/optim.py
@@ -36,13 +36,13 @@ class OptimizerWrapper(Optimizer):
         self.optim = optim
         self.manager = manager
 
-    def add_param_group(self, param_group: object) -> None:
+    def add_param_group(self, param_group: Dict[str, Any]) -> None:
         self.optim.add_param_group(param_group)
 
-    def load_state_dict(self, state_dict: object) -> None:
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         self.optim.load_state_dict(state_dict)
 
-    def state_dict(self) -> object:
+    def state_dict(self) -> Dict[str, Any]:
         return self.optim.state_dict()
 
     def zero_grad(self, set_to_none: bool = True) -> None:

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -387,7 +387,6 @@ class ProcessGroupWrapper(ProcessGroup):
         pg = self._pg
         if pg is not None:
             if hasattr(pg, "abort"):
-                # pyre-fixme[16]: has no attribute abort
                 pg.abort()
             else:
                 try:
@@ -395,7 +394,6 @@ class ProcessGroupWrapper(ProcessGroup):
                 except RuntimeError:
                     backend = None
                 if backend is not None and hasattr(backend, "abort"):
-                    # pyre-fixme[16]: no attribute abort
                     backend.abort()
 
             self._pg = None

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -997,7 +997,7 @@ class MultiPgBaseTest(TestCase):
         self._collect(futs)
 
 
-class GlooMultiPgTest(MultiPgBaseTest):
+class NormalGlooMultiPgTest(MultiPgBaseTest):
     BACKEND = "gloo"
     WORLD_SIZE = 3
     SKIP = [


### PR DESCRIPTION
This updates the minimum version of torch to be 2.7.0. There's some important fixes in PyTorch 2.7 that avoid crashes and other slow behavior.

CI has been flaky recently in large part due to segfaults caused by bugs in 2.6.

Test plan:

CI