### PR TITLE
ProcessGroupNCCL: abort on get_future timeout

### DIFF
--- a/torchft/torchx.py
+++ b/torchft/torchx.py
@@ -64,7 +64,11 @@ def hsdp(
                 num_replicas=workers_per_replica,
                 resource=specs.resource(cpu=cpu, gpu=gpu, memMB=memMB, h=h),
                 max_retries=0,
-                env=env,
+                env={
+                    "REPLICA_GROUP_ID": str(replica_id),
+                    "NUM_REPLICA_GROUPS": str(replicas),
+                    **env,
+                },
                 entrypoint="torchrun",
                 args=cmd,
             )


### PR DESCRIPTION
This has some key fixes to improve ProcessGroupNCCL abort behavior when timing out.

This previously had a bug where weren't correctly scheduling the stream_timeout when calling `.get_future()` as called by `allreduce()` in the torchft Manager.

This also modifies `train_ddp.py` to allow for running multiple workers on the same GPU + make it more network heavy so we stress the comm layer and abort.

Test plan:

Added new unit tests to `process_group_test.py`.

```
pytest torchft/process_group_test.py -v -s -x -k test_nccl_timeouts
```

train_ddp + failure injection via `kill`

```
torchx run -- --replicas 16 --max_restarts=10
```
