### PR TITLE
lighthouse: add commit_failures support

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -42,6 +42,7 @@ message QuorumMember {
     int64 step = 4;
     uint64 world_size = 5;
     bool shrink_only = 6;
+    int64 commit_failures = 8;
     // User passing in data stored as JSON string.
     string data = 7;
 }
@@ -77,6 +78,7 @@ message ManagerQuorumRequest {
     string checkpoint_metadata = 3;
     bool shrink_only = 4;
     bool init_sync = 5;
+    int64 commit_failures = 6;
 }
 
 message ManagerQuorumResponse {
@@ -93,6 +95,7 @@ message ManagerQuorumResponse {
     int64 replica_rank = 9;
     int64 replica_world_size = 10;
     bool heal = 11;
+    int64 commit_failures = 12;
 }
 
 message CheckpointMetadataRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ impl ManagerClient {
         checkpoint_metadata: String,
         shrink_only: bool,
         init_sync: bool,
+        commit_failures: i64,
         timeout: Duration,
     ) -> Result<QuorumResult, StatusError> {
         py.allow_threads(move || {
@@ -186,6 +187,7 @@ impl ManagerClient {
                 checkpoint_metadata: checkpoint_metadata,
                 shrink_only: shrink_only,
                 init_sync: init_sync,
+                commit_failures: commit_failures,
             });
 
             // This timeout is processed on the server side so we also enable
@@ -547,6 +549,7 @@ impl LighthouseClient {
                     world_size: world_size,
                     shrink_only: shrink_only,
                     data: data_string,
+                    commit_failures: 0,
                 }),
             });
 

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -11,6 +11,7 @@ class ManagerClient:
         checkpoint_metadata: str,
         shrink_only: bool,
         timeout: timedelta,
+        commit_failures: int,
         init_sync: bool = True,
     ) -> QuorumResult: ...
     def _checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
@@ -34,6 +35,7 @@ class QuorumResult:
     max_rank: Optional[int]
     max_world_size: int
     heal: bool
+    commit_failures: int
 
 class ManagerServer:
     def __init__(

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -470,6 +470,7 @@ class Manager:
                 shrink_only=shrink_only,
                 timeout=quorum_timeout,
                 init_sync=self._init_sync,
+                commit_failures=self._commit_failures,
             )
 
         quorum_id = quorum.quorum_id


### PR DESCRIPTION
This adds a new field to Lighthouse quorum for `commit_failures`. When a commit failure occurs, a network error has occurred and we thus force a new quorum to ensure that all workers reconfigure.

This is required so #182 will gracefully recover after failure.

Test plan:

```
cargo test
pytest torchft/manager_integ_test.py
```