### PR TITLE
process_group/gloo: support CUDA tensors

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -560,6 +560,10 @@ class ProcessGroupGloo(ProcessGroupWrapper):
         pg._register_backend(
             torch.device("cpu"), ProcessGroup.BackendType.GLOO, backend_class
         )
+        if torch.cuda.is_available():
+            pg._register_backend(
+                torch.device("cuda"), ProcessGroup.BackendType.GLOO, backend_class
+            )
         return pg
 
     def getBackendName(self) -> str:


### PR DESCRIPTION
This makes torchft's ProcessGroupGloo correctly support CUDA tensors so we can use Gloo with torchtitan for allreduces.

I also found a bug in Gloo, apparently torchft's test suite is more in depth than the one in core haha https://github.com/pytorch/pytorch/issues/152645

Test plan:

torchtitan on remote cluster

```
pytest torchft/process_group_test.py -k gloo_apis
```