### PR TITLE
Distinguishing between replica rank and group rank across the project (#181)

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -73,7 +73,7 @@ service LighthouseService {
 }
 
 message ManagerQuorumRequest {
-    int64 rank = 1;
+    int64 group_rank = 1;
     int64 step = 2;
     string checkpoint_metadata = 3;
     bool shrink_only = 4;
@@ -84,12 +84,12 @@ message ManagerQuorumRequest {
 message ManagerQuorumResponse {
     int64 quorum_id = 1;
     string recover_src_manager_address = 2;
-    optional int64 recover_src_rank = 3;
-    repeated int64 recover_dst_ranks = 4;
+    optional int64 recover_src_replica_rank = 3;
+    repeated int64 recover_dst_replica_ranks = 4;
     string store_address = 5;
     // These are information for the replicas which are at the max step.
     int64 max_step = 6;
-    optional int64 max_rank = 7;
+    optional int64 max_replica_rank = 7;
     int64 max_world_size = 8;
     // These are information for all replicas including behind replicas.
     int64 replica_rank = 9;
@@ -108,7 +108,7 @@ message CheckpointMetadataResponse {
 
 message ShouldCommitRequest {
     bool should_commit = 1;
-    int64 rank = 2;
+    int64 group_rank = 2;
     int64 step = 3;
 }
 message ShouldCommitResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl ManagerClient {
     fn _quorum(
         &self,
         py: Python<'_>,
-        rank: i64,
+        group_rank: i64,
         step: i64,
         checkpoint_metadata: String,
         shrink_only: bool,
@@ -182,7 +182,7 @@ impl ManagerClient {
     ) -> Result<QuorumResult, StatusError> {
         py.allow_threads(move || {
             let mut request = tonic::Request::new(ManagerQuorumRequest {
-                rank: rank,
+                group_rank: group_rank,
                 step: step,
                 checkpoint_metadata: checkpoint_metadata,
                 shrink_only: shrink_only,
@@ -201,11 +201,11 @@ impl ManagerClient {
                 replica_rank: resp.replica_rank,
                 replica_world_size: resp.replica_world_size,
                 recover_src_manager_address: resp.recover_src_manager_address,
-                recover_src_rank: resp.recover_src_rank,
-                recover_dst_ranks: resp.recover_dst_ranks,
+                recover_src_replica_rank: resp.recover_src_replica_rank,
+                recover_dst_replica_ranks: resp.recover_dst_replica_ranks,
                 store_address: resp.store_address,
                 max_step: resp.max_step,
-                max_rank: resp.max_rank,
+                max_replica_rank: resp.max_replica_rank,
                 max_world_size: resp.max_world_size,
                 heal: resp.heal,
             })
@@ -250,14 +250,14 @@ impl ManagerClient {
     fn should_commit(
         &self,
         py: Python<'_>,
-        rank: i64,
+        group_rank: i64,
         step: i64,
         should_commit: bool,
         timeout: Duration,
     ) -> Result<bool, StatusError> {
         py.allow_threads(move || {
             let mut request = tonic::Request::new(ShouldCommitRequest {
-                rank: rank,
+                group_rank: group_rank,
                 step: step,
                 should_commit: should_commit,
             });
@@ -281,11 +281,11 @@ struct QuorumResult {
     replica_rank: i64,
     replica_world_size: i64,
     recover_src_manager_address: String,
-    recover_src_rank: Option<i64>,
-    recover_dst_ranks: Vec<i64>,
+    recover_src_replica_rank: Option<i64>,
+    recover_dst_replica_ranks: Vec<i64>,
     store_address: String,
     max_step: i64,
-    max_rank: Option<i64>,
+    max_replica_rank: Option<i64>,
     max_world_size: i64,
     heal: bool,
 }
@@ -299,11 +299,11 @@ impl QuorumResult {
             replica_rank: 0,
             replica_world_size: 1,
             recover_src_manager_address: "".to_string(),
-            recover_src_rank: None,
-            recover_dst_ranks: Vec::new(),
+            recover_src_replica_rank: None,
+            recover_dst_replica_ranks: Vec::new(),
             store_address: "".to_string(),
             max_step: 0,
-            max_rank: None,
+            max_replica_rank: None,
             max_world_size: 1,
             heal: false,
         }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -235,9 +235,9 @@ impl ManagerService for Arc<Manager> {
         request: Request<ManagerQuorumRequest>,
     ) -> Result<Response<ManagerQuorumResponse>, Status> {
         let req = request.get_ref();
-        let rank = req.rank;
+        let group_rank = req.group_rank;
 
-        info_with_replica!(self.replica_id, "Start quorum for rank {}", rank);
+        info_with_replica!(self.replica_id, "Start quorum for group_rank {}", group_rank);
 
         let timeout = try_parse_grpc_timeout(&request.metadata())
             .map_err(|e| {
@@ -255,7 +255,7 @@ impl ManagerService for Arc<Manager> {
             // TODO: make separate call to set?
             state
                 .checkpoint_metadata
-                .insert(req.rank, req.checkpoint_metadata.clone());
+                .insert(req.group_rank, req.checkpoint_metadata.clone());
 
             let member = QuorumMember {
                 replica_id: self.replica_id.clone(),
@@ -268,7 +268,7 @@ impl ManagerService for Arc<Manager> {
                 commit_failures: req.commit_failures,
             };
             // TODO check step
-            state.participants.insert(rank, member.clone());
+            state.participants.insert(group_rank, member.clone());
             let rx = state.channel.subscribe();
 
             self._run_quorum(&mut state, member, timeout).await?;
@@ -281,9 +281,13 @@ impl ManagerService for Arc<Manager> {
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
-        info_with_replica!(self.replica_id, "Finished quorum for rank {}", rank);
+        info_with_replica!(
+            self.replica_id,
+            "Finished quorum for group_rank {}",
+            group_rank
+        );
 
-        let reply = compute_quorum_results(&self.replica_id, rank, &quorum, req.init_sync)?;
+        let reply = compute_quorum_results(&self.replica_id, group_rank, &quorum, req.init_sync)?;
 
         Ok(Response::new(reply))
     }
@@ -312,12 +316,12 @@ impl ManagerService for Arc<Manager> {
         request: Request<ShouldCommitRequest>,
     ) -> Result<Response<ShouldCommitResponse>, Status> {
         let req = request.into_inner();
-        let rank = req.rank;
+        let group_rank = req.group_rank;
 
         info_with_replica!(
             self.replica_id,
             "should_commit request from {} should_commit={}",
-            rank,
+            group_rank,
             req.should_commit
         );
 
@@ -327,9 +331,9 @@ impl ManagerService for Arc<Manager> {
             let mut state = self.state.lock().await;
 
             if !req.should_commit {
-                state.should_commit_failures.insert(rank);
+                state.should_commit_failures.insert(group_rank);
             }
-            state.should_commit_count.insert(rank);
+            state.should_commit_count.insert(group_rank);
 
             let rx = state.should_commit_channel.subscribe();
 
@@ -377,7 +381,7 @@ impl ManagerService for Arc<Manager> {
 
 fn compute_quorum_results(
     replica_id: &str,
-    rank: i64,
+    group_rank: i64,
     quorum: &Quorum,
     init_sync: bool,
 ) -> Result<ManagerQuorumResponse, Status> {
@@ -408,7 +412,7 @@ fn compute_quorum_results(
     let max_step = participants.iter().map(|p| p.step).max().unwrap();
     let max_participants: Vec<&QuorumMember> =
         participants.iter().filter(|p| p.step == max_step).collect();
-    let max_rank = max_participants.iter().enumerate().find_map(|(i, p)| {
+    let max_replica_rank = max_participants.iter().enumerate().find_map(|(i, p)| {
         if p.replica_id == replica_id {
             Some(i as i64)
         } else {
@@ -417,8 +421,9 @@ fn compute_quorum_results(
     });
 
     // The primary TCPStore to use for this rank.
-    let primary_rank = rank as usize % max_participants.len();
-    let primary = max_participants[primary_rank];
+    // There is one TCPStore per replica.
+    let primary_replica_rank = group_rank as usize % max_participants.len();
+    let primary = max_participants[primary_replica_rank];
 
     // Compute recovery assignments
 
@@ -427,7 +432,7 @@ fn compute_quorum_results(
     // Nodes are recovering if
     // 1. not at the max step (init_sync)
     // 2. max_step == 0 and not the primary replica
-    let all_recover_dst_ranks: Vec<usize> = participants
+    let all_recover_dst_replica_ranks: Vec<usize> = participants
         .iter()
         .enumerate()
         .filter_map(|(i, p)| {
@@ -439,12 +444,13 @@ fn compute_quorum_results(
         })
         .collect();
 
-    let all_recover_dst_ranks_set = all_recover_dst_ranks.iter().collect::<HashSet<_>>();
+    let all_recover_dst_replica_ranks_set =
+        all_recover_dst_replica_ranks.iter().collect::<HashSet<_>>();
     let up_to_date_ranks: Vec<usize> = participants
         .iter()
         .enumerate()
         .filter_map(|(i, _p)| {
-            if !all_recover_dst_ranks_set.contains(&i) {
+            if !all_recover_dst_replica_ranks_set.contains(&i) {
                 Some(i)
             } else {
                 None
@@ -455,34 +461,34 @@ fn compute_quorum_results(
     // This is a map of rank to the ranks that are recovering from that node.
     let mut recovery_assignments: HashMap<usize, Vec<i64>> = HashMap::new();
     // The rank of the node that this rank is recovering from.
-    let mut recover_src_rank: Option<i64> = None;
-    for (i, recovering_rank) in all_recover_dst_ranks.iter().enumerate() {
-        let up_to_date_idx = (i + rank as usize) % up_to_date_ranks.len();
-        let recovering_recover_src_rank = up_to_date_ranks[up_to_date_idx];
-        if !recovery_assignments.contains_key(&recovering_recover_src_rank) {
-            recovery_assignments.insert(recovering_recover_src_rank, Vec::new());
+    let mut recover_src_replica_rank: Option<i64> = None;
+    for (i, recovering_rank) in all_recover_dst_replica_ranks.iter().enumerate() {
+        let up_to_date_idx = (i + group_rank as usize) % up_to_date_ranks.len();
+        let recovering_recover_src_replica_rank = up_to_date_ranks[up_to_date_idx];
+        if !recovery_assignments.contains_key(&recovering_recover_src_replica_rank) {
+            recovery_assignments.insert(recovering_recover_src_replica_rank, Vec::new());
         }
         recovery_assignments
-            .get_mut(&recovering_recover_src_rank)
+            .get_mut(&recovering_recover_src_replica_rank)
             .unwrap()
             .push(*recovering_rank as i64);
         if *recovering_rank == replica_rank {
-            recover_src_rank = Some(recovering_recover_src_rank as i64);
+            recover_src_replica_rank = Some(recovering_recover_src_replica_rank as i64);
         }
     }
 
-    let heal = recover_src_rank.is_some();
+    let heal = recover_src_replica_rank.is_some();
     if heal {
         info_with_replica!(
             replica_id,
-            "healing is required step={}, max_step={}, recover_src_rank={}",
+            "healing is required step={}, max_step={}, recover_src_replica_rank={}",
             step,
             max_step,
-            recover_src_rank.unwrap()
+            recover_src_replica_rank.unwrap()
         );
     }
 
-    let recover_src_manager_address = match recover_src_rank {
+    let recover_src_manager_address = match recover_src_replica_rank {
         Some(r) => participants[r as usize].address.clone(),
         None => "".to_string(),
     };
@@ -491,13 +497,13 @@ fn compute_quorum_results(
         quorum_id: quorum.quorum_id,
         // address is used for looking up the checkpoint server address.
         recover_src_manager_address: recover_src_manager_address,
-        recover_src_rank: recover_src_rank,
-        recover_dst_ranks: recovery_assignments
+        recover_src_replica_rank: recover_src_replica_rank,
+        recover_dst_replica_ranks: recovery_assignments
             .get(&replica_rank)
             .map_or_else(Vec::new, |v| v.clone()),
         store_address: primary.store_address.clone(),
         max_step: max_step,
-        max_rank: max_rank,
+        max_replica_rank: max_replica_rank,
         max_world_size: max_participants.len() as i64,
         replica_rank: replica_rank as i64,
         replica_world_size: participants.len() as i64,
@@ -515,7 +521,7 @@ mod tests {
     use super::*;
     use crate::lighthouse::{Lighthouse, LighthouseOpt};
 
-    async fn should_commit(rank: i64, should_commit: bool) -> Result<ShouldCommitResponse> {
+    async fn should_commit(group_rank: i64, should_commit: bool) -> Result<ShouldCommitResponse> {
         let mut client = manager_client_new(
             "http://localhost:29531".to_string(),
             Duration::from_secs(10),
@@ -523,7 +529,7 @@ mod tests {
         .await?;
 
         let request = tonic::Request::new(ShouldCommitRequest {
-            rank: rank,
+            group_rank: group_rank,
             step: 1,
             should_commit: should_commit,
         });
@@ -607,7 +613,7 @@ mod tests {
         let mut client = manager_client_new(manager.address(), Duration::from_secs(10)).await?;
 
         let mut request = tonic::Request::new(ManagerQuorumRequest {
-            rank: 0,
+            group_rank: 0,
             step: 123,
             checkpoint_metadata: "addr".to_string(),
             shrink_only: false,
@@ -624,7 +630,7 @@ mod tests {
         assert_eq!(resp.recover_src_manager_address, "".to_string());
         assert_eq!(resp.store_address, "store_addr".to_string());
         assert_eq!(resp.max_step, 123);
-        assert_eq!(resp.max_rank, Some(0));
+        assert_eq!(resp.max_replica_rank, Some(0));
         assert_eq!(resp.max_world_size, 1);
         assert_eq!(resp.replica_rank, 0);
         assert_eq!(resp.replica_world_size, 1);
@@ -669,7 +675,7 @@ mod tests {
                     manager_client_new(manager.address(), Duration::from_secs(10)).await?;
 
                 let mut request = tonic::Request::new(ManagerQuorumRequest {
-                    rank: 0,
+                    group_rank: 0,
                     step: 0,
                     checkpoint_metadata: "addr".to_string(),
                     shrink_only: false,
@@ -787,22 +793,22 @@ mod tests {
         let results = compute_quorum_results("replica_0", 0, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 0);
-        assert_eq!(results.recover_src_rank, None);
-        assert_eq!(results.recover_dst_ranks, vec![1]);
+        assert_eq!(results.recover_src_replica_rank, None);
+        assert_eq!(results.recover_dst_replica_ranks, vec![1]);
 
         let results = compute_quorum_results("replica_1", 0, &quorum, true)?;
         assert!(results.heal);
         assert_eq!(results.replica_rank, 1);
-        assert_eq!(results.recover_src_rank, Some(0));
-        assert_eq!(results.recover_dst_ranks, Vec::<i64>::new());
+        assert_eq!(results.recover_src_replica_rank, Some(0));
+        assert_eq!(results.recover_dst_replica_ranks, Vec::<i64>::new());
 
         // rank 1 assignments should be offset from rank 0 above and the primary
 
         let results = compute_quorum_results("replica_1", 1, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 1);
-        assert_eq!(results.recover_src_rank, None);
-        assert_eq!(results.recover_dst_ranks, vec![0]);
+        assert_eq!(results.recover_src_replica_rank, None);
+        assert_eq!(results.recover_dst_replica_ranks, vec![0]);
 
         Ok(())
     }
@@ -872,29 +878,29 @@ mod tests {
         assert!(results.heal);
         assert_eq!(results.recover_src_manager_address, "addr_1".to_string());
         assert_eq!(results.replica_rank, 0);
-        assert_eq!(results.recover_src_rank, Some(1));
-        assert!(results.recover_dst_ranks.is_empty());
+        assert_eq!(results.recover_src_replica_rank, Some(1));
+        assert!(results.recover_dst_replica_ranks.is_empty());
 
         let results = compute_quorum_results("replica_1", 0, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.recover_src_manager_address, "".to_string());
         assert_eq!(results.replica_rank, 1);
-        assert_eq!(results.recover_src_rank, None);
-        assert_eq!(results.recover_dst_ranks, vec![0, 4]);
+        assert_eq!(results.recover_src_replica_rank, None);
+        assert_eq!(results.recover_dst_replica_ranks, vec![0, 4]);
 
         let results = compute_quorum_results("replica_3", 0, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 3);
-        assert_eq!(results.recover_src_rank, None);
-        assert_eq!(results.recover_dst_ranks, vec![2]);
+        assert_eq!(results.recover_src_replica_rank, None);
+        assert_eq!(results.recover_dst_replica_ranks, vec![2]);
 
         // rank 1 assignments should be offset from rank 0 above
 
         let results = compute_quorum_results("replica_1", 1, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 1);
-        assert_eq!(results.recover_src_rank, None);
-        assert_eq!(results.recover_dst_ranks, vec![2]);
+        assert_eq!(results.recover_src_replica_rank, None);
+        assert_eq!(results.recover_dst_replica_ranks, vec![2]);
 
         Ok(())
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -237,7 +237,11 @@ impl ManagerService for Arc<Manager> {
         let req = request.get_ref();
         let group_rank = req.group_rank;
 
-        info_with_replica!(self.replica_id, "Start quorum for group_rank {}", group_rank);
+        info_with_replica!(
+            self.replica_id,
+            "Start quorum for group_rank {}",
+            group_rank
+        );
 
         let timeout = try_parse_grpc_timeout(&request.metadata())
             .map_err(|e| {

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -6,7 +6,7 @@ class ManagerClient:
     def __init__(self, addr: str, connect_timeout: timedelta) -> None: ...
     def _quorum(
         self,
-        rank: int,
+        group_rank: int,
         step: int,
         checkpoint_metadata: str,
         shrink_only: bool,
@@ -17,7 +17,7 @@ class ManagerClient:
     def _checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
     def should_commit(
         self,
-        rank: int,
+        group_rank: int,
         step: int,
         should_commit: bool,
         timeout: timedelta,
@@ -28,11 +28,11 @@ class QuorumResult:
     replica_rank: int
     replica_world_size: int
     recover_src_manager_address: str
-    recover_src_rank: Optional[int]
-    recover_dst_ranks: List[int]
+    recover_src_replica_rank: Optional[int]
+    recover_dst_replica_ranks: List[int]
     store_address: str
     max_step: int
-    max_rank: Optional[int]
+    max_replica_rank: Optional[int]
     max_world_size: int
     heal: bool
     commit_failures: int

--- a/torchft/data.py
+++ b/torchft/data.py
@@ -38,34 +38,34 @@ class DistributedSampler(data.distributed.DistributedSampler):
     This will shard the input dataset into ``num_replicas*num_replica_group``
     number of shards.
 
-    Each shard rank is calculated via: ``rank + num_replicas*replica_group``
+    Each shard rank is calculated via: ``rank + num_replicas*replica_rank``
 
-    num_replicas and replica_group must be the same on all workers.
+    num_replicas and replica_rank must be the same on all workers.
     """
 
     def __init__(
         self,
         dataset: data.Dataset,
-        replica_group: int,
+        replica_rank: int,
         num_replica_groups: int,
-        rank: Optional[int] = None,
+        group_rank: Optional[int] = None,
         num_replicas: Optional[int] = None,
         **kwargs: object,
     ) -> None:
         """
         Args:
             data: the dataset to use
-            replica_group: the group ID (0-num_replica_groups) to use for this shard of data.
+            replica_rank: the group ID (0-num_replica_groups) to use for this shard of data.
             num_replica_groups: the max number of global replica groups
             rank: the local group rank
             num_replicas: the local group world size
         """
-        if rank is None:
-            rank = dist.get_rank()
+        if group_rank is None:
+            group_rank = dist.get_rank()
         if num_replicas is None:
             num_replicas = dist.get_world_size()
 
-        self.global_rank: int = rank + num_replicas * replica_group
+        self.global_rank: int = group_rank + num_replicas * replica_rank
         self.global_world_size: int = num_replicas * num_replica_groups
 
         super().__init__(

--- a/torchft/data_test.py
+++ b/torchft/data_test.py
@@ -27,9 +27,9 @@ class TestData(TestCase):
         dataset = DummyDataset(1000)
         sampler = DistributedSampler(
             dataset,
-            replica_group=1,
+            replica_rank=1,
             num_replica_groups=2,
-            rank=3,
+            group_rank=3,
             num_replicas=4,
         )
         self.assertEqual(sampler.global_rank, 3 + 1 * 4)

--- a/torchft/manager_test.py
+++ b/torchft/manager_test.py
@@ -146,7 +146,7 @@ class TestManager(TestCase):
         quorum.recover_src_manager_address = "manager address"
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 1
-        quorum.max_rank = 1
+        quorum.max_replica_rank = 1
         quorum.max_world_size = 2
         quorum.heal = False
 
@@ -180,10 +180,10 @@ class TestManager(TestCase):
         quorum.replica_rank = 1
         quorum.replica_world_size = 2
         quorum.recover_src_manager_address = "manager address"
-        quorum.recover_src_rank = 0
+        quorum.recover_src_replica_rank = 0
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 20
-        quorum.max_rank = None
+        quorum.max_replica_rank = None
         quorum.max_world_size = 2
         quorum.heal = True
 
@@ -234,10 +234,10 @@ class TestManager(TestCase):
         quorum.replica_rank = 1
         quorum.replica_world_size = 2
         quorum.recover_src_manager_address = "manager address"
-        quorum.recover_src_rank = 0
+        quorum.recover_src_replica_rank = 0
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 20
-        quorum.max_rank = None
+        quorum.max_replica_rank = None
         quorum.max_world_size = 1
         quorum.heal = True
 
@@ -296,10 +296,10 @@ class TestManager(TestCase):
         quorum.replica_rank = 1
         quorum.replica_world_size = 2
         quorum.recover_src_manager_address = "manager address"
-        quorum.recover_src_rank = 0
+        quorum.recover_src_replica_rank = 0
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 20
-        quorum.max_rank = None
+        quorum.max_replica_rank = None
         quorum.max_world_size = 1
         quorum.heal = True
 
@@ -358,7 +358,7 @@ class TestManager(TestCase):
         quorum.recover_src_manager_address = "manager address"
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 1
-        quorum.max_rank = 1
+        quorum.max_replica_rank = 1
         quorum.max_world_size = 2
         quorum.heal = False
 
@@ -427,7 +427,7 @@ class TestManager(TestCase):
         quorum.recover_src_manager_address = "manager address"
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 1
-        quorum.max_rank = 1
+        quorum.max_replica_rank = 1
         quorum.max_world_size = 2
         quorum.heal = False
 
@@ -465,7 +465,7 @@ class TestManager(TestCase):
             quorum.recover_src_manager_address = "manager address"
             quorum.store_address = f"localhost:{self.store.port}"
             quorum.max_step = 1
-            quorum.max_rank = rank
+            quorum.max_replica_rank = rank
             quorum.max_world_size = 3
             quorum.heal = False
 
@@ -497,10 +497,10 @@ class TestManager(TestCase):
         quorum.replica_rank = 0
         quorum.replica_world_size = 3
         quorum.recover_src_manager_address = "manager address"
-        quorum.recover_src_rank = 1
+        quorum.recover_src_replica_rank = 1
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 1
-        quorum.max_rank = None
+        quorum.max_replica_rank = None
         quorum.max_world_size = 2
         quorum.heal = True
         client_mock()._quorum.return_value = quorum
@@ -568,8 +568,8 @@ class TestManager(TestCase):
         manager._quorum_future = quorum_future = MagicMock(
             spec=concurrent.futures.Future
         )
-        manager._participating_rank = 1
-        manager._participating_world_size = 5
+        manager._participating_replica_rank = 1
+        manager._participating_replica_world_size = 5
         self.assertEqual(manager.num_participants(), 5)
         self.assertEqual(quorum_future.result.call_count, 1)
         self.assertEqual(manager.participating_rank(), 1)
@@ -603,7 +603,7 @@ class TestManager(TestCase):
         quorum.recover_src_manager_address = "manager address"
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 1
-        quorum.max_rank = 1
+        quorum.max_replica_rank = 1
         quorum.max_world_size = 2
         quorum.heal = False
 
@@ -636,7 +636,7 @@ class TestManager(TestCase):
         quorum.recover_src_manager_address = "manager address"
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 1
-        quorum.max_rank = 1
+        quorum.max_replica_rank = 1
         quorum.max_world_size = 2
         quorum.heal = False
 
@@ -664,10 +664,10 @@ class TestManager(TestCase):
         quorum.replica_rank = 1
         quorum.replica_world_size = 2
         quorum.recover_src_manager_address = "manager address"
-        quorum.recover_src_rank = 0
+        quorum.recover_src_replica_rank = 0
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 20
-        quorum.max_rank = None
+        quorum.max_replica_rank = None
         quorum.max_world_size = 2
         quorum.heal = True
 
@@ -682,7 +682,7 @@ class TestManager(TestCase):
         with self.assertRaisesRegex(RuntimeError, "recv failure"):
             raise error
 
-        quorum.recover_dst_ranks = [0]
+        quorum.recover_dst_replica_ranks = [0]
         manager.start_quorum()
         manager.wait_quorum()
         self.assertFalse(manager.should_commit())
@@ -705,10 +705,10 @@ class TestManager(TestCase):
         quorum.replica_rank = 1
         quorum.replica_world_size = 2
         quorum.recover_src_manager_address = "manager address"
-        quorum.recover_src_rank = 0
+        quorum.recover_src_replica_rank = 0
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 20
-        quorum.max_rank = None
+        quorum.max_replica_rank = None
         quorum.max_world_size = 2
 
         client_mock()._quorum.return_value = quorum
@@ -735,7 +735,7 @@ class TestManager(TestCase):
         quorum.recover_src_manager_address = "manager address"
         quorum.store_address = f"localhost:{self.store.port}"
         quorum.max_step = 1
-        quorum.max_rank = 1
+        quorum.max_replica_rank = 1
         quorum.max_world_size = 2
         quorum.heal = False
         client_mock()._quorum.return_value = quorum

--- a/train_ddp.py
+++ b/train_ddp.py
@@ -53,7 +53,7 @@ def main() -> None:
         trainset,
         replica_group=REPLICA_GROUP_ID,
         num_replica_groups=NUM_REPLICA_GROUPS,
-        rank=0,
+        group_rank=0,
         # for DDP we can use replica groups of size 1, FSDP/PP/CP would need more.
         num_replicas=1,
         shuffle=True,


### PR DESCRIPTION
Distinguishes between replica rank and group rank across the projects as per #181.

Kept the API the same for all except for the DistributedSampler. I found the terminology especially confusing there. And since it is not used in torchTitan I changed the API.

All tests have passed. However, I am getting the following linter error. It doesn't seem like a problem with my code. 

```sh
@warren# lintrunner -a
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.

>>> General linter failure:

  Advice (pyre) command-failed
    Failed due to JSONDecodeError:
    Expecting value: line 1 column 1 (char 0)
Successfully applied all patches.
(/srv/apps/danny/miniconda3/envs/warren/torchtitan) root@sz-k8s-master:/srv/apps/warren/fork/torchft# 
```

# Changes

## Globally
Changed recovery_src_rank, recovery_dst_ranks, max_rank to `_replica_rank`. 

## In Manager.py:

```python
rank -> group_rank
self._rank -> self._group_rank
self._participating_rank -> self._participating_replica_rank
self._participating_world_size -> self._participating_replica_world_size 
max_world_size -> max_replica_world_size world_size -> group_world_size 
self._world_size_mode -> self._replica_world_size_mode
```

## In Data.py

Changed API along with internal reference:

```python
rank -> group_rank
replica_group -> replica_rank
```

## In Rust Code

`ShouldCommitRequest:` rank -> group_rank
`self._client._quorum`: rank -> group_rank
Did not change CheckpointMetadataRequest's proto interface since it should be it seems less tied to the specific group_rank/replica rank distinction made here.