### PR TITLE
 Support multiple quorums on a single LighthouseServer using gRPC metadata-based room assignment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ askama = "0.12.1"
 atty = "0.2.14"
 axum = "0.7.7"
 chrono = "0.4.40"
+dashmap = "6.1"
 fern = {version = "0.7.1", features = ["colored"]}
 gethostname = "0.5.0"
 log = "0.4.22"
@@ -21,6 +22,7 @@ slog-stdlog = "4.1.1"
 stderrlog = "0.6.0"
 structopt = "0.3.26"
 tokio = {version = "1.40.0", features = ["full", "test-util", "tracing", "macros", "rt-multi-thread"] }
+tokio-stream = "0.1"
 tonic = "0.12.2"
 
 [build-dependencies]

--- a/src/bin/lighthouse.rs
+++ b/src/bin/lighthouse.rs
@@ -4,8 +4,11 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+use std::net::SocketAddr;
 use structopt::StructOpt;
-use torchft::lighthouse::{Lighthouse, LighthouseOpt};
+use torchft::lighthouse::LighthouseOpt;
+use torchft::router::Router;
+use torchftpb::lighthouse_service_server::LighthouseServiceServer;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() {
@@ -17,7 +20,10 @@ async fn main() {
         .unwrap();
 
     let opt = LighthouseOpt::from_args();
-    let lighthouse = Lighthouse::new(opt).await.unwrap();
-
-    lighthouse.run().await.unwrap();
+    let router = Router::new(opt.clone());
+    Server::builder()
+        .add_service(LighthouseServiceServer::new(router))
+        .serve(opt.bind.parse::<SocketAddr>().unwrap())
+        .await
+        .unwrap();
 }

--- a/src/lighthouse.rs
+++ b/src/lighthouse.rs
@@ -83,7 +83,7 @@ impl ChangeLogger {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Clone)]
 #[structopt()]
 pub struct LighthouseOpt {
     // bind is the address to bind the server to.

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use dashmap::{mapref::entry::Entry, DashMap};
+use tonic::{Request, Response, Status};
+
+use crate::{
+    lighthouse::{Lighthouse, LighthouseOpt},
+    torchftpb::{
+        lighthouse_service_server::LighthouseService, LighthouseHeartbeatRequest,
+        LighthouseHeartbeatResponse, LighthouseQuorumRequest, LighthouseQuorumResponse,
+    },
+};
+
+/// Metadata header for both client and router
+pub const ROOM_ID_HEADER: &str = "room-id";
+
+/// Top-level service registered with tonic’s `Server::builder()`
+#[derive(Clone)]
+pub struct Router {
+    rooms: Arc<DashMap<String, Arc<Lighthouse>>>,
+    tmpl_opt: LighthouseOpt, // (cloned for each new room)
+}
+
+/// Designates a single tonic gRPC server into many logical “rooms.”
+/// Inspects the `room-id` metadata header on each request, then
+/// lazily creates or reuses an Arc<Lighthouse> for that namespace
+impl Router {
+    /// Create a new router given the CLI/config options that are
+    /// normally passed straight to `Lighthouse::new`.
+    pub fn new(tmpl_opt: LighthouseOpt) -> Self {
+        Self {
+            rooms: Arc::new(DashMap::new()),
+            tmpl_opt,
+        }
+    }
+
+    /// Room lookup: creation if it doesn't exist, access if it does
+    async fn room(&self, id: &str) -> Arc<Lighthouse> {
+        // 1. Quick optimistic read (no locking contention).
+        if let Some(handle) = self.rooms.get(id) {
+            return handle.clone();
+        }
+
+        // 2. Build the Lighthouse instance *off the map* so
+        //    we don't hold any guard across `.await`.
+        let new_room = Lighthouse::new(self.tmpl_opt.clone())
+            .await
+            .expect("failed to create Lighthouse");
+
+        // 3. Second pass: insert if still vacant, otherwise reuse
+        //    whatever another task inserted first.
+        match self.rooms.entry(id.to_owned()) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                entry.insert(new_room.clone());
+                new_room
+            }
+        }
+    }
+
+    /// Extracts `"room-id"` from metadata, defaulting to `"default"`.
+    fn extract_room_id(meta: &tonic::metadata::MetadataMap) -> &str {
+        meta.get(ROOM_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("default")
+    }
+}
+
+#[tonic::async_trait]
+impl LighthouseService for Router {
+    async fn quorum(
+        &self,
+        req: Request<LighthouseQuorumRequest>,
+    ) -> Result<Response<LighthouseQuorumResponse>, Status> {
+        let id = Self::extract_room_id(req.metadata()).to_owned();
+        let room = self.room(&id).await;
+        <Arc<Lighthouse> as LighthouseService>::quorum(&room, req).await
+    }
+
+    async fn heartbeat(
+        &self,
+        req: Request<LighthouseHeartbeatRequest>,
+    ) -> Result<Response<LighthouseHeartbeatResponse>, Status> {
+        let id = Self::extract_room_id(req.metadata()).to_owned();
+        let room = self.room(&id).await;
+        <Arc<Lighthouse> as LighthouseService>::heartbeat(&room, req).await
+    }
+}

--- a/torchft/multi_quorum_test.py
+++ b/torchft/multi_quorum_test.py
@@ -1,0 +1,46 @@
+"""
+Validate that one Lighthouse server can host isolated quorums
+for multiple logical rooms (job IDs) via `room-id` metadata header.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+
+import torchft._torchft as ext
+
+_TIMEOUT = _dt.timedelta(seconds=3)  # connect + RPC timeout
+
+
+def _client(addr: str, room: str) -> ext.LighthouseClient:
+    """Utility: create a client with a logical room-id."""
+    return ext.LighthouseClient(addr, _TIMEOUT, room)
+
+
+@pytest.mark.asyncio
+async def test_multi_room_quorums() -> None:
+    # 1) one server, any free port
+    server = ext.LighthouseServer("[::]:0", 1)
+    addr = server.address()
+
+    # 2) two clients in two separate rooms
+    a = _client(addr, "jobA")
+    b = _client(addr, "jobB")
+
+    # 3) explicit heartbeats (exercises RPC path)
+    a.heartbeat("a0")
+    b.heartbeat("b0")
+
+    # 4) ask for a quorum from each room
+    qa = a.quorum("a0", _TIMEOUT)
+    qb = b.quorum("b0", _TIMEOUT)
+
+    # 5) verify the rooms are independent
+    assert qa.quorum_id == qb.quorum_id == 1
+    assert len(qa.participants) == 1 and qa.participants[0].replica_id == "a0"
+    assert len(qb.participants) == 1 and qb.participants[0].replica_id == "b0"
+
+    # 6) shutdown
+    server.shutdown()


### PR DESCRIPTION
GH Issue: https://github.com/pytorch/torchft/issues/173

Extends Lighthouse to to support multiple independent quorums on a single server by tagging each gRPC call with a `room-id` metadata header and feeding requests through a lightweight router that maintains per‐room state with a `DashMap<String, Arc<Lighthouse>>`. `LighthouseClient` now accepts an optional `room_id` argument and automatically injects the corresponding metadata header into each `heartbeat` and `quorum` request, while untagged calls continue to use a default namespace. In `multi_quorum_test.py`, I created 2 clients with distinct room ID's and have them form independent quorums on the same server port.

Open to making any changes to the code or approach 🤙.

Warmly,
Matt