### PR TITLE
Introduce FP8 reduce-scatter along with SUM and more base types

### DIFF
--- a/torchft/collectives.py
+++ b/torchft/collectives.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
+
 from typing import TYPE_CHECKING
 
 import torch
@@ -11,11 +13,12 @@ import torch
 # pyre-ignore[21]: Could not find a module corresponding to import `triton`
 import triton
 from torch import cuda
+from torch.distributed import ReduceOp
 from torch.distributed.distributed_c10d import (
     AllgatherOptions,
     AllreduceOptions,
     AllToAllOptions,
-    ReduceOp,
+    ReduceScatterOptions,
 )
 from torch.futures import Future
 
@@ -29,16 +32,252 @@ from torchft.quantization import (
 )
 
 
-def _to_alltoall_options(opts: AllreduceOptions) -> AllToAllOptions:
+def _to_alltoall_options(
+    opts: AllreduceOptions | ReduceScatterOptions,
+) -> AllToAllOptions:
     alltoall_opts = AllToAllOptions()
     alltoall_opts.timeout = opts.timeout
     return alltoall_opts
 
 
-def _to_allgather_options(opts: AllreduceOptions) -> AllgatherOptions:
+def _to_allgather_options(
+    opts: AllreduceOptions | ReduceScatterOptions,
+) -> AllgatherOptions:
     allgather_opts = AllgatherOptions()
     allgather_opts.timeout = opts.timeout
     return allgather_opts
+
+
+def get_padded_sizes(
+    tensors: list[torch.Tensor],
+    world_size: int,
+) -> list[torch.Size]:
+    """
+    Calculate padded sizes for tensors to ensure they can be evenly
+    divided across ranks.
+
+    This function computes padded tensor sizes by rounding up the
+    first dimension of each tensor to be a multiple of the world_size.
+    This ensures that when tensors are split across ranks
+    in distributed operations, each process receives an equal
+    number of elements.
+
+    Args:
+        tensors: List of tensors whose sizes need to be padded
+        world_size: Number of ranks in the distributed setup
+
+    Returns:
+        List of torch.Size objects with the first dimension padded
+        to be a multiple of world_size
+
+    Note:
+        For 1D tensors, they are treated as 2D tensors with a
+        second dimension of 1
+    """
+    padded_sizes = []
+    for tensor in tensors:
+        size = tensor.size()
+        if len(size) == 1:
+            size = (size[0], 1)
+        padded_m = math.ceil(size[0] / world_size) * world_size
+        padded_sizes.append(torch.Size((padded_m, *size[1:])))
+    return padded_sizes
+
+
+def allocate_reduce_scatter_output(
+    tensors: list[torch.Tensor],
+    world_size: int,
+) -> tuple[torch.Tensor, list[torch.Size]]:
+    """
+    Allocate tensor for the output of a reduce-scatter operation.
+
+    This function creates a single contiguous tensor to hold the results of a
+    reduce-scatter operation across multiple ranks. It ensures that the tensor
+    is properly sized and shaped to accommodate the results, where each rank
+    will receive a portion of the reduced data.
+
+    Args:
+        tensors: List of input tensors for the reduce-scatter operation.
+                All tensors must be on the same device and have the same
+                data type.
+        world_size: Number of ranks in the distributed setup
+
+    Returns:
+        A tuple containing:
+        - A single contiguous tensor allocated for the reduce-scatter output
+        - A list of padded sizes for the input tensors that were split across
+          ranks
+
+    Raises:
+        AssertionError: If the input tensors are not all on the same device or
+                       do not all have the same data type
+    """
+    device = tensors[0].device
+    dtype = tensors[0].dtype
+    for i in range(1, len(tensors)):
+        assert (
+            tensors[i].device == tensors[i - 1].device
+        ), "All inputs must be on the same device"
+        assert (
+            tensors[i].dtype == tensors[i - 1].dtype
+        ), "All inputs must be on the same dtype"
+
+    padded_sizes = get_padded_sizes(tensors, world_size)
+
+    chunks = []
+    numels = [size.numel() // world_size for size in padded_sizes]
+    tensor = torch.empty(
+        (sum(numels),),
+        device=device,
+        dtype=dtype,
+    )
+    for split, padded_size in zip(torch.split(tensor, numels), padded_sizes):
+        chunks.append(split.view(padded_size[0] // world_size, *padded_size[1:]))
+    return tensor, padded_sizes
+
+
+class _QuantizedOpFuture(Future[None]):
+    def __init__(
+        self,
+        sync_stream: cuda.Stream,
+        keep_alive_tensors: list[torch.Tensor],
+    ) -> None:
+        super().__init__()
+        self._sync_stream = sync_stream
+        self._keep_alive_tensors = keep_alive_tensors
+
+    def wait(self) -> None:
+        # Wait for the synchronization to complete.
+        cuda.current_stream().wait_stream(self._sync_stream)
+        # Clean up intermediate buffers.
+        del self._keep_alive_tensors
+
+
+def reduce_scatter_quantized(
+    output: torch.Tensor,
+    inputs: list[torch.Tensor],
+    opts: ReduceScatterOptions | ReduceOp,
+    process_group: ProcessGroup,
+    sync_stream: cuda.Stream | None = None,
+) -> Future[None]:
+    """
+    Performs a quantized reduce-scatter operation on a list of tensors.
+
+    This function implements an optimized reduce-scatter that reduces communication
+    overhead by quantizing tensors to FP8 format before sending them over the
+    network. The algorithm works as follows:
+
+    1. Quantize input tensors to FP8 format
+    2. Distribute chunks of quantized tensors to all ranks using all-to-all
+    3. Reduce chunks locally in higher precision after dequantization
+    4. Dequantize the result back to the original precision for the current rank
+
+    This implementation only supports the AVG and SUM reduce operations.
+
+    Args:
+        output: Pre-allocated tensor to store the output of the reduce-scatter operation
+        inputs: List of tensors to be reduced and scattered. All tensors must be on
+                the same CUDA device and have the same dtype.
+        opts: Options for the reduce-scatter operation. Can be either a
+              ReduceScatterOptions object or a ReduceOp enum.
+        process_group: The process group to perform the reduce-scatter on.
+        sync_stream: Optional CUDA stream to use for synchronization. If None,
+                    a new stream will be created.
+
+    Returns:
+        A Future that can be used to wait for the operation to complete and
+        clean up intermediate buffers.
+
+    Raises:
+        NotImplementedError: If the reduce operation is not ReduceOp.AVG or ReduceOp.SUM.
+    """
+
+    if isinstance(opts, ReduceOp):
+        reducescatter_opts = ReduceScatterOptions()
+        reducescatter_opts.reduceOp = opts
+    else:
+        reducescatter_opts = opts
+
+    # Check if the reduceOp is AVG or SUM
+    if reducescatter_opts.reduceOp not in {
+        ReduceOp(ReduceOp.AVG),
+        ReduceOp(ReduceOp.SUM),
+    }:
+        raise NotImplementedError(
+            f"ReduceOp {reducescatter_opts.reduceOp} is not supported "
+            f"for quantized reduce-scatter, only AVG and SUM are supported"
+        )
+
+    rank = process_group.rank()
+    world_size = process_group.size()
+
+    reduce_output_sizes = [
+        torch.Size((s[0] // world_size, *s[1:]))
+        for s in get_padded_sizes(inputs, world_size)
+    ]
+    reduce_output_numels = [s.numel() for s in reduce_output_sizes]
+    reduce_outputs = [
+        o.view(s)
+        for o, s in zip(
+            output.split(reduce_output_numels),
+            reduce_output_sizes,
+        )
+    ]
+
+    if sync_stream is None:
+        sync_stream = cuda.Stream()
+
+    assert sync_stream is not None
+    # Ensure that all operations are completed on the current stream
+    # before proceeding with all-reduce
+    sync_stream.wait_stream(cuda.current_stream())
+    with cuda.stream(sync_stream):
+        # Quantize tensoers and compute their scales, all inlined in the
+        # output tensor.
+        quantized_inputs = fused_quantize_into_fp8(inputs, world_size)
+
+        # Allocate output tensor where all-reduce results will be stored
+        quantized_inputs_out = torch.zeros_like(quantized_inputs)
+        # Collect chunks and their scales from other ranks
+        process_group.alltoall_base(
+            quantized_inputs_out.view(world_size, -1),
+            quantized_inputs.view(world_size, -1),
+            [],
+            [],
+            _to_alltoall_options(reducescatter_opts),
+        ).wait()
+
+        # Reduce chunks locally in higher precision after dequantization.
+        # The output is again quantized.
+        fused_reduce_fp8(
+            inputs,
+            quantized_inputs_out,
+            world_size,
+            rank,
+            reducescatter_opts.reduceOp,
+        )
+
+        # Get view into the output tensor that corresponds to the
+        # current rank
+        quantized_reduce_scatter = (
+            quantized_inputs_out.view(world_size, -1).split(1)[rank].squeeze(0)
+        )
+        # Dequantize the result back to the original precision for
+        # the current rank
+        fused_dequantize_from_fp8(
+            reduce_outputs,
+            quantized_reduce_scatter,
+            1,
+        )
+
+        # pyre-ignore[29]
+        return _QuantizedOpFuture(
+            sync_stream,
+            [
+                quantized_inputs,
+                quantized_inputs_out,
+            ],
+        )
 
 
 def allreduce_quantized(
@@ -85,11 +324,14 @@ def allreduce_quantized(
     else:
         allreduce_opts = opts
 
-    # Check if the reduceOp is AVG, as only AVG is supported
-    if allreduce_opts.reduceOp != ReduceOp.AVG:
+    # Check if the reduceOp is AVG or SUM
+    if allreduce_opts.reduceOp not in {
+        ReduceOp(ReduceOp.AVG),
+        ReduceOp(ReduceOp.SUM),
+    }:
         raise NotImplementedError(
             f"ReduceOp {allreduce_opts.reduceOp} is not supported "
-            f"for quantized allreduce, only AVG is supported"
+            f"for quantized allreduce, only AVG and SUM are supported"
         )
 
     rank = process_group.rank()
@@ -125,6 +367,7 @@ def allreduce_quantized(
             quantized_tensors_out,
             world_size,
             rank,
+            allreduce_opts.reduceOp,
         )
 
         # Collect reduced chunks from other ranks.
@@ -137,26 +380,11 @@ def allreduce_quantized(
         # Dequantize and copy to output buffer.
         fused_dequantize_from_fp8(tensors, quantized_tensors, world_size)
 
-        class QuantizedAllReduceFuture(Future[None]):
-            def __init__(
-                self,
-                sync_stream: cuda.Stream,
-                quantized_tensors: torch.Tensor,
-                quantized_tensors_out: torch.Tensor,
-            ) -> None:
-                super().__init__()
-                self._sync_stream = sync_stream
-                self._quantized_tensors = quantized_tensors
-                self._quantized_tensors_out = quantized_tensors_out
-
-            def wait(self) -> None:
-                # Wait for the synchronization to complete.
-                cuda.current_stream().wait_stream(self._sync_stream)
-                # Clean up intermediate buffers.
-                del self._quantized_tensors_out
-                del self._quantized_tensors
-
         # pyre-ignore[29]
-        return QuantizedAllReduceFuture(
-            sync_stream, quantized_tensors, quantized_tensors_out
+        return _QuantizedOpFuture(
+            sync_stream,
+            [
+                quantized_tensors,
+                quantized_tensors_out,
+            ],
         )

--- a/torchft/collectives.py
+++ b/torchft/collectives.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-
 from typing import TYPE_CHECKING
 
 import torch
@@ -157,7 +156,7 @@ def reduce_scatter_quantized(
     output: torch.Tensor,
     inputs: list[torch.Tensor],
     opts: ReduceScatterOptions | ReduceOp,
-    process_group: ProcessGroup,
+    process_group: "ProcessGroup",
     sync_stream: cuda.Stream | None = None,
 ) -> Future[None]:
     """

--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -205,7 +205,7 @@ else:
                     3,
                     tensor_size,
                     multiplier,
-                    0.04,
+                    0.05,
                     reduce_op,
                     dtype,
                 )

--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -9,10 +9,10 @@ from typing import Callable
 from unittest import TestCase, skipUnless
 
 import torch
+import torch.distributed as dist
 from parameterized import parameterized
 from torch import cuda
-from torch.distributed import AllreduceOptions, ReduceOp
-from torch.distributed.distributed_c10d import ReduceOp
+from torch.distributed import ReduceOp, ReduceScatterOptions
 
 from torchft import _test_utils
 from torchft.process_group import ProcessGroup
@@ -24,7 +24,24 @@ try:
 except ImportError:
     pass
 else:
-    from torchft.collectives import allreduce_quantized
+    from torchft.collectives import (
+        allocate_reduce_scatter_output,
+        allreduce_quantized,
+        get_padded_sizes,
+        reduce_scatter_quantized,
+    )
+
+    def _check_result_tolerance(
+        actual: torch.Tensor, expected: torch.Tensor, tolerance: float
+    ) -> None:
+        diff = torch.abs(
+            (expected - actual).div(expected.to(torch.float32) + 0.0000001)
+        )
+        mean_diff = diff.mean().item()
+
+        if mean_diff > tolerance:
+            print(f"Diff: {diff=}\n{expected=}\n{actual=}")
+            raise AssertionError(f"Results not within tolerance {tolerance}")
 
     @skipUnless(
         torch.cuda.is_available() and torch.cuda.device_count() >= 2,
@@ -46,21 +63,22 @@ else:
 
             self._collect(futures)
 
-        def _run_collective(
+        def _run_all_reduce_collective(
             self,
             pg: ProcessGroup,
-            rank: int,
             device: str,
             tensors_num: int,
             tensor_size: int,
             multiplier: float,
             tolerance: float,
+            reduce_op: ReduceOp,
+            dtype: torch.dtype,
         ) -> None:
             cuda.set_device(device)
             inp = (
                 torch.rand(
                     tensors_num * tensor_size,
-                    dtype=torch.float32,
+                    dtype=dtype,
                     device=device,
                 )
                 * multiplier
@@ -76,34 +94,119 @@ else:
                     )
                 ]
 
-                fut = allreduce_quantized(tensors, ReduceOp.AVG, pg)
+                fut = allreduce_quantized(tensors, reduce_op, pg)
                 fut.wait()
 
-                work = pg.allreduce([expected], ReduceOp.AVG)
+                work = pg.allreduce([expected], reduce_op)
                 work.get_future().wait()
 
-                diff = torch.abs((expected - actual).div(expected))
-                mean_diff = diff.mean().item()
+                _check_result_tolerance(actual, expected, tolerance)
 
-                if mean_diff > tolerance:
-                    raise AssertionError(f"Results not within tolerance {tolerance}")
+        def _run_reduce_scatter_collective(
+            self,
+            pg: ProcessGroup,
+            device: str,
+            tensors_num: int,
+            tensor_size: int,
+            multiplier: float,
+            tolerance: float,
+            reduce_op: ReduceOp,
+            dtype: torch.dtype,
+        ) -> None:
+            cuda.set_device(device)
+            inp = (
+                torch.rand(
+                    tensors_num * tensor_size,
+                    dtype=dtype,
+                    device=device,
+                )
+                * multiplier
+            )
+            world_size = pg.size()
+            for split in _test_utils.gen_splits(inp, tensor_size):
+                actual = inp.clone()
+                tensors = [
+                    i.view(*s)
+                    for s, i in zip(
+                        split,
+                        torch.split(actual, tensor_size),
+                    )
+                ]
 
-        END_TO_END_CONFIGS: list[tuple[int, float]] = [
-            (ts, m)
-            for ts in [128, 512, 1024, 2048, 4096]
+                actual_output, _ = allocate_reduce_scatter_output(
+                    tensors,
+                    world_size,
+                )
+
+                opts = ReduceScatterOptions()
+                opts.reduceOp = reduce_op
+
+                fut = reduce_scatter_quantized(actual_output, tensors, opts, pg)
+                fut.wait()
+
+                padded_sizes = get_padded_sizes(tensors, world_size)
+                padded_numel = sum(s.numel() for s in padded_sizes)
+
+                padded_input = torch.empty(padded_numel, dtype=dtype, device=device)
+                torch._chunk_cat(
+                    tensors, dim=0, num_chunks=world_size, out=padded_input
+                )
+
+                expected_output = torch.empty(
+                    padded_numel // world_size, dtype=dtype, device=device
+                )
+
+                work = pg.reduce_scatter([expected_output], [[padded_input]], opts)
+                work.get_future().wait()
+
+                _check_result_tolerance(actual_output, expected_output, tolerance)
+
+        END_TO_END_CONFIGS: list[tuple[int, float, ReduceOp, torch.dtype]] = [
+            (ts, m, o, t)
+            for ts in [256, 1024, 4096]
             for m in [1.0, 10.0, 100.0, 1000.0]
+            for o in [ReduceOp.AVG, ReduceOp.SUM]
+            for t in [torch.float32, torch.float16, torch.bfloat16]
         ]
 
         @parameterized.expand(END_TO_END_CONFIGS)
-        def test_collective(self, tensor_size: int, multiplier: float) -> None:
+        def test_all_reduce_collective(
+            self,
+            tensor_size: int,
+            multiplier: float,
+            reduce_op: ReduceOp,
+            dtype: torch.dtype,
+        ) -> None:
             self._run_parallel_collectives(
-                lambda pg, rank, device: self._run_collective(
+                lambda pg, _, device: self._run_all_reduce_collective(
                     pg,
-                    rank,
                     device,
                     3,
                     tensor_size,
                     multiplier,
-                    3.0,
+                    0.04,
+                    reduce_op,
+                    dtype,
+                )
+            )
+
+        @parameterized.expand(END_TO_END_CONFIGS)
+        def test_reduce_scatter_collective(
+            self,
+            tensor_size: int,
+            multiplier: float,
+            reduce_op: ReduceOp,
+            dtype: torch.dtype,
+        ) -> None:
+            self._run_parallel_collectives(
+                lambda pg, _, device: self._run_reduce_scatter_collective(
+                    pg,
+                    device,
+                    3,
+                    tensor_size,
+                    multiplier,
+                    0.04,
+                    reduce_op,
+                    dtype,
                 )
             )

--- a/torchft/quantization.py
+++ b/torchft/quantization.py
@@ -16,6 +16,7 @@ import triton.language as tl
 
 # pyre-ignore[21]: Could not find a module corresponding to import `triton.runtime`
 import triton.runtime as tr
+from torch.distributed import ReduceOp
 
 SCALE_DTYPE: torch.dtype = torch.float32
 SCALE_DTYPE_BYTES: int = 4
@@ -49,6 +50,7 @@ def _fused_kernel_quantize_into_fp8(
     i_shapes,
     i_strides,
     i_offsets,
+    i_dtype,
     o_ptr,
     o_size_bytes_per_rank,
     all_reduce_size,
@@ -68,6 +70,7 @@ def _fused_kernel_quantize_into_fp8(
         i_shapes: Shapes of the input tensors to be quantized
         i_strides: Strides of the input tensors to be quantized
         i_offsets: Offsets of the output tensors for each input tensor
+        i_dtype: Dummy tensor that carries the dtype of the input tensors
         o_ptr: Pointer to the output tensor for the quantized input and scales
         o_size_bytes_per_rank: Size in bytes in the output tensor per rank
         all_reduce_size: Size of the all-reduce group
@@ -91,7 +94,7 @@ def _fused_kernel_quantize_into_fp8(
     i_col_stride = tl.load(i_strides + i_idx * 2 + 1)
 
     # Pointer to the input tensor
-    i_ptr = tl.load(i_ptrs + i_idx).to(tl.pointer_type(tl.float32))
+    i_ptr = tl.load(i_ptrs + i_idx).to(i_dtype.dtype)
 
     # Number of the rows in the input tensor that are processed by a single
     # rank
@@ -158,6 +161,7 @@ def _fused_kernel_dequantize_from_fp8(
     i_shapes,
     i_strides,
     i_offsets,
+    i_dtype,
     o_ptr,
     o_size_bytes_per_rank,
     all_reduce_size,
@@ -174,6 +178,7 @@ def _fused_kernel_dequantize_from_fp8(
         i_shapes: Shapes of the input tensors to be dequantized into
         i_strides: Strides of the input tensors to be dequantized into
         i_offsets: Offsets of the output tensors for each input tensor
+        i_dtype: Dummy tensor that carries the dtype of the input tensors
         o_ptr: Pointer to the tensor that contains output of the quantization
             or local reduction
         o_size_bytes_per_rank: Size in bytes in the output tensor per rank
@@ -197,7 +202,7 @@ def _fused_kernel_dequantize_from_fp8(
     i_col_stride = tl.load(i_strides + i_idx * 2 + 1)
 
     # Pointer to the input tensor
-    i_ptr = tl.load(i_ptrs + i_idx).to(tl.pointer_type(tl.float32))
+    i_ptr = tl.load(i_ptrs + i_idx).to(i_dtype.dtype)
 
     # Number of the rows in the input tensor that are processed by a single
     # rank
@@ -235,7 +240,9 @@ def _fused_kernel_dequantize_from_fp8(
             other=0.0,
         )
 
-        i_dequant_row_block = i_quant_row_block.to(tl.float32) / i_row_scale
+        i_dequant_row_block = (
+            i_quant_row_block.to(i_dtype.dtype.element_ty) / i_row_scale
+        )
         tl.store(
             i_ptr + i_row_idx * i_row_stride + col_offsets * i_col_stride,
             i_dequant_row_block,
@@ -252,6 +259,7 @@ def _fused_kernel_reduce_fp8(
     o_size_bytes_per_rank,
     all_reduce_size,
     all_reduce_rank,
+    division_factor,
     BLOCK_SIZE: tl.constexpr,
     TL_FP8_TYPE: tl.constexpr,
 ) -> None:
@@ -271,6 +279,7 @@ def _fused_kernel_reduce_fp8(
         o_size_bytes_per_rank: Size in bytes in the output tensor per rank
         all_reduce_size: Size of the all-reduce group
         all_reduce_rank: Rank in the all-reduce group
+        division_factor: Division factor for the reduction result
         BLOCK_SIZE: Block size for the reduction
         NUM_SM: Number of SMs to use for the reduction
     """
@@ -320,7 +329,7 @@ def _fused_kernel_reduce_fp8(
         col_offsets += BLOCK_SIZE
 
     # Compute scaling factor for the reduced row
-    o_row_scale = _kernel_calculate_scale(o_row_max / all_reduce_size)
+    o_row_scale = _kernel_calculate_scale(o_row_max / division_factor)
 
     o_rank_row_ptr = o_ptr + all_reduce_rank * o_size_bytes_per_rank + o_offset
     o_rank_scale_ptr = o_rank_row_ptr.to(tl.pointer_type(SCALE_TL_DTYPE))
@@ -344,7 +353,7 @@ def _fused_kernel_reduce_fp8(
             col_offsets_mask,
             TL_FP8_TYPE,
         )
-        o_row_block_acc = o_row_block_acc * o_row_scale / all_reduce_size
+        o_row_block_acc = o_row_block_acc * o_row_scale / division_factor
         o_quant_row_block_acc = o_row_block_acc.to(TL_FP8_TYPE)
         tl.store(
             o_rank_quant_ptr + col_offsets,
@@ -398,6 +407,8 @@ def _fused_kernel_accumulate_block(
         )
 
         o_row_scale = tl.load(o_scale_ptr)
+        # Ensure that we do not divide by zero when reducing "padding" rows
+        o_row_scale = tl.where(o_row_scale == 0.0, 1.0, o_row_scale)
         o_row_quant_block = tl.load(
             o_quant_ptr + col_offsets,
             mask=col_mask,
@@ -412,7 +423,14 @@ def _fused_kernel_accumulate_block(
 def _prepare_quantize_fp8(
     inputs: list[torch.Tensor], all_reduce_group_size: int
 ) -> tuple[
-    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int, torch.device
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    int,
+    int,
+    torch.device,
 ]:
     """
     Prepares the inputs for the quantization, dequantization and reduction kernels.
@@ -427,6 +445,7 @@ def _prepare_quantize_fp8(
         d_i_strides: Row strides of the input tensors
         d_i_offsets: Offsets into the output tensor for each rank for each input
             tensor.
+        d_i_dtype: The type of the input tensors
         output_size: Size of the output tensor in bytes including necessary padding
         i_max_row_num: Maximum number of rows in the input tensors
         device: Device of the input tensors
@@ -435,10 +454,14 @@ def _prepare_quantize_fp8(
     i_num = len(inputs)
     assert i_num > 0, "At least one input tensor is required"
     device = inputs[0].device
+    dtype = inputs[0].dtype
     for i in range(1, i_num):
         assert (
             inputs[i].device == inputs[i - 1].device
         ), "All inputs must be on the same device"
+        assert (
+            inputs[i].dtype == inputs[i - 1].dtype
+        ), "All inputs must be on the same dtype"
     i_ptrs = []
     i_shapes = []
     i_strides = []
@@ -447,6 +470,8 @@ def _prepare_quantize_fp8(
     i_max_row_num = 0
     output_size_per_rank = 0
     for i in range(i_num):
+        if len(inputs[i].shape) == 1:
+            inputs[i] = inputs[i].unsqueeze(1)
         assert len(inputs[i].shape) == 2, "Only 2D tensors are supported"
         i_ptrs.append(inputs[i].data_ptr())
         i_m, i_n = inputs[i].shape
@@ -480,6 +505,7 @@ def _prepare_quantize_fp8(
         d_i_shapes,
         d_i_strides,
         d_i_offsets,
+        torch.tensor(1.0, dtype=dtype, device=device),
         output_size,
         i_max_row_num,
         device,
@@ -514,6 +540,7 @@ def fused_quantize_into_fp8(
         d_i_shapes,
         d_i_strides,
         d_i_offsets,
+        d_i_dtype,
         output_size,
         i_max_row_num,
         device,
@@ -533,6 +560,7 @@ def fused_quantize_into_fp8(
         d_i_shapes,
         d_i_strides,
         d_i_offsets,
+        d_i_dtype,
         output,
         output_size // all_reduce_group_size,
         all_reduce_group_size,
@@ -567,6 +595,7 @@ def fused_dequantize_from_fp8(
         d_i_shapes,
         d_i_strides,
         d_i_offsets,
+        d_i_dtype,
         output_size,
         i_max_row_num,
         device,
@@ -580,6 +609,7 @@ def fused_dequantize_from_fp8(
         d_i_shapes,
         d_i_strides,
         d_i_offsets,
+        d_i_dtype,
         output,
         output_size // all_reduce_group_size,
         all_reduce_group_size,
@@ -593,6 +623,7 @@ def fused_reduce_fp8(
     output: torch.Tensor,
     all_reduce_group_size: int,
     all_reduce_rank: int,
+    reduce_op: ReduceOp = ReduceOp.SUM,
 ) -> None:
     """
     Reduces rows of the output tensor for the given rank. The output tensor
@@ -615,6 +646,7 @@ def fused_reduce_fp8(
         d_i_shapes,
         d_i_strides,
         d_i_offsets,
+        d_i_dtype,
         output_size,
         i_max_row_num,
         device,
@@ -630,6 +662,7 @@ def fused_reduce_fp8(
         output_size // all_reduce_group_size,
         all_reduce_group_size,
         all_reduce_rank,
+        1.0 if reduce_op == ReduceOp.SUM else float(all_reduce_group_size),
         BLOCK_SIZE=BLOCK_SIZE_T,
         TL_FP8_TYPE=_get_fp8_type(),
     )

--- a/torchft/quantization.py
+++ b/torchft/quantization.py
@@ -470,6 +470,12 @@ def _prepare_quantize_fp8(
         assert (
             inputs[i].dtype == inputs[i - 1].dtype
         ), "All inputs must be on the same dtype"
+
+    assert dtype in [
+        torch.float32,
+        torch.float16,
+        torch.bfloat16,
+    ], "Only fp32, fp16 and bf16 are supported"
     i_ptrs = []
     i_shapes = []
     i_strides = []
@@ -508,12 +514,14 @@ def _prepare_quantize_fp8(
     d_i_offsets = torch.empty(i_num, dtype=torch.int32, device=device)
     d_i_offsets.copy_(torch.tensor(i_offsets, dtype=torch.int32), non_blocking=True)
 
+    d_i_dtype = torch.empty(1, dtype=dtype, device=device)
+
     return (
         d_i_ptrs,
         d_i_shapes,
         d_i_strides,
         d_i_offsets,
-        torch.tensor(1.0, dtype=dtype, device=device),
+        d_i_dtype,
         output_size,
         i_max_row_num,
         device,

--- a/torchft/quantization_test.py
+++ b/torchft/quantization_test.py
@@ -8,6 +8,7 @@ from unittest import TestCase, skipUnless
 
 import torch
 from parameterized import parameterized
+from torch.distributed import ReduceOp
 
 from torchft import _test_utils
 
@@ -40,11 +41,13 @@ else:
             tensor_size: int,
             multiplier: float,
             tolerance: float,
+            reduce_op: ReduceOp,
+            type: torch.dtype,
         ) -> None:
             inp = (
                 torch.rand(
                     tensors_num * tensor_size,
-                    dtype=torch.float32,
+                    dtype=type,
                     device="cuda",
                 )
                 * multiplier
@@ -81,7 +84,9 @@ else:
                     for other in range(world_size):
                         quant_copy_slices[other].copy_(quant_slices[r])
 
-                    fused_reduce_fp8(reshaped_inputs, quant_copy, world_size, r)
+                    fused_reduce_fp8(
+                        reshaped_inputs, quant_copy, world_size, r, reduce_op
+                    )
 
                     quant_final_slices[r].copy_(quant_copy_slices[r])
 
@@ -89,24 +94,39 @@ else:
 
                 self.assertFalse(_test_utils.any_nan(reshaped_outputs))
 
-                diff = torch.abs((inputs - outputs).div(inputs))
+                if reduce_op == ReduceOp.SUM:
+                    inputs.mul_(world_size)
+
+                diff = torch.abs(
+                    (inputs - outputs).div(inputs.to(torch.float32) + 0.0000001)
+                )
                 mean_diff = diff.mean().item()
                 self.assertLessEqual(
                     mean_diff, tolerance, f"Results not within tolerance {tolerance}"
                 )
 
-        END_TO_END_CONFIGS: list[tuple[int, float]] = [
-            (ts, m)
-            for ts in [128, 256, 512, 1024, 2048, 4096]
+        END_TO_END_CONFIGS: list[tuple[int, float, ReduceOp, torch.dtype]] = [
+            (ts, m, o, t)
+            for ts in [128, 256, 1024, 4096]
             for m in [1.0, 10.0, 100.0, 1000.0]
+            for o in [ReduceOp.AVG, ReduceOp.SUM]
+            for t in [torch.float32, torch.float16, torch.bfloat16]
         ]
 
         @parameterized.expand(END_TO_END_CONFIGS)
-        def test_end_to_end(self, tensor_size: int, multiplier: float) -> None:
+        def test_end_to_end(
+            self,
+            tensor_size: int,
+            multiplier: float,
+            reduce_op: ReduceOp,
+            type: torch.dtype,
+        ) -> None:
             self.run_test(
                 world_size=2,
                 tensors_num=4,
                 tensor_size=tensor_size,
                 multiplier=multiplier,
-                tolerance=3.0,
+                tolerance=0.03,
+                reduce_op=reduce_op,
+                type=type,
             )

--- a/torchft/quantization_test.py
+++ b/torchft/quantization_test.py
@@ -126,7 +126,7 @@ else:
                 tensors_num=4,
                 tensor_size=tensor_size,
                 multiplier=multiplier,
-                tolerance=0.03,
+                tolerance=0.05,
                 reduce_op=reduce_op,
                 type=type,
             )


### PR DESCRIPTION
This change introduces several extensions to the quantized collectives:

- FP8 reduce-scatter
- float16 and bfloat16 base types for the input tensors
- SUM reduce operation support