### PR TITLE
Group work for each commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,13 @@ A test DDP script can be launched with torchX with:
 torchx run
 ```
 
-See [.torchxconfig](.torchxconfig), [torchx.py](./torchft/torchx.py) and the [torchX documentation](https://pytorch.org/torchx/latest/) to understand how DDP is being ran. 
+Or Diloco with:
+
+```sh
+USE_STREAMING=True torchx run ./torchft/torchx.py:hsdp --script='train_diloco.py'
+```
+
+See [.torchxconfig](.torchxconfig), [torchx.py](./torchft/torchx.py) and the [torchX documentation](https://pytorch.org/torchx/latest/) to understand how DDP is being ran.
 
 `torchx.py` could also launch HSDP jobs when `workers_per_replica` is set > 1, if the training script supports it. For an example HSDP training implementation with torchFT enabled, see [torchtitan](https://github.com/pytorch/torchtitan).
 

--- a/torchft/manager_test.py
+++ b/torchft/manager_test.py
@@ -164,9 +164,7 @@ class TestManager(TestCase):
 
         manager.start_quorum()
         manager.allreduce(torch.tensor([1.0])).wait()
-        self.assertEqual(len(manager._pending_work), 1)
         self.assertTrue(manager.should_commit())
-        self.assertEqual(len(manager._pending_work), 0)
 
         self.assertEqual(manager._quorum_id, 123)
         self.assertEqual(manager.current_step(), 1)
@@ -553,8 +551,6 @@ class TestManager(TestCase):
         assert error is not None
         self.assertIs(error.original_exception, e)
         self.assertEqual(wrapped_fut.value(), 2)
-
-        self.assertEqual(manager._pending_work, [wrapped_fut])
 
     @patch("torchft.manager.ManagerClient", autospec=True)
     def test_manager_wrap_future_timeout(self, client_mock: MagicMock) -> None:

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -775,7 +775,7 @@ class ProcessGroupNCCL(ProcessGroupWrapper):
 
     def errored(self) -> Optional[Exception]:
         # force a synchronization to ensure all work is complete
-        torch.cuda.synchronize()
+        torch.cuda.current_stream().synchronize()
 
         return self._errored
 

--- a/train_ddp.py
+++ b/train_ddp.py
@@ -51,7 +51,7 @@ def main() -> None:
     # majority of groups will be available so few batches will be dropped.
     sampler = DistributedSampler(
         trainset,
-        replica_group=REPLICA_GROUP_ID,
+        replica_rank=REPLICA_GROUP_ID,
         num_replica_groups=NUM_REPLICA_GROUPS,
         group_rank=0,
         # for DDP we can use replica groups of size 1, FSDP/PP/CP would need more.

--- a/train_diloco.py
+++ b/train_diloco.py
@@ -1,0 +1,226 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import sys
+from datetime import timedelta
+
+REPLICA_GROUP_ID = int(os.environ.get("REPLICA_GROUP_ID", 0))
+os.environ["CUDA_VISIBLE_DEVICES"] = str(REPLICA_GROUP_ID % 4)
+os.environ["NCCL_HOSTID"] = str(REPLICA_GROUP_ID)
+
+USE_STREAMING = os.getenv("USE_STREAMING", "False") == "True"
+
+import torch
+import torch.nn.functional as F
+import torchvision
+import torchvision.transforms as transforms
+from torch import nn, optim
+from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.pipelining import SplitPoint, pipeline
+from torch.export import export
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from torchft import (
+    DistributedSampler,
+    Manager,
+    ProcessGroupBabyNCCL,
+    ProcessGroupGloo,
+    ProcessGroupNCCL,
+)
+from torchft.checkpointing.pg_transport import PGTransport
+from torchft.local_sgd import DiLoCo
+
+logging.basicConfig(level=logging.INFO)
+
+
+@record
+def main() -> None:
+    REPLICA_GROUP_ID = int(os.environ.get("REPLICA_GROUP_ID", 0))
+    NUM_REPLICA_GROUPS = int(os.environ.get("NUM_REPLICA_GROUPS", 2))
+
+    def load_state_dict(state_dict):
+        m.load_state_dict(state_dict["model"])
+        inner_optimizer.load_state_dict(state_dict["inner_optim"])
+        outer_optimizer.load_state_dict(state_dict["outer_optim"])
+
+    def state_dict():
+        return {
+            "model": m.state_dict(),
+            "inner_optim": inner_optimizer.state_dict(),
+            "outer_optim": outer_optimizer.state_dict(),
+        }
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    pg = (
+        ProcessGroupBabyNCCL(
+            timeout=timedelta(seconds=10),
+        )
+        if torch.cuda.is_available()
+        else ProcessGroupGloo(timeout=timedelta(seconds=5))
+    )
+
+    transport = PGTransport(
+        pg,
+        timeout=timedelta(seconds=10),
+        device=("cuda" if torch.cuda.is_available() else "cpu"),
+    )
+
+    manager = Manager(
+        pg=pg,
+        use_async_quorum=False,
+        min_replica_size=1,
+        load_state_dict=load_state_dict,
+        state_dict=state_dict,
+        replica_id=f"train_diloco_{REPLICA_GROUP_ID}",
+        timeout=timedelta(seconds=30),
+        checkpoint_transport=transport,
+    )
+
+    class DummyDataset(torch.utils.data.Dataset):
+        def __init__(self, size=10000, feature_dim=128, num_classes=10):
+            """
+            Create a dummy dataset suitable for MLP models.
+
+            Args:
+                size: Number of samples in the dataset
+                feature_dim: Dimension of the feature vector (should match d_hid in MultiMLP)
+                num_classes: Number of output classes
+            """
+            self.size = size
+            self.feature_dim = feature_dim
+            self.num_classes = num_classes
+
+        def __len__(self):
+            return self.size
+
+        def __getitem__(self, idx):
+            # Generate random feature vector (1D) instead of image (3D)
+            features = torch.rand(self.feature_dim)
+            label = torch.randint(0, self.num_classes, (1,)).item()
+            return features, label
+
+    # MLP Layer
+    class MLPModule(torch.nn.Module):
+        def __init__(self, d_hid: int):
+            super().__init__()
+            self.net1 = torch.nn.Linear(d_hid, d_hid)
+            self.relu = torch.nn.ReLU()
+            self.net2 = torch.nn.Linear(d_hid, d_hid)
+
+            target_size = 500 * (1 << 20)
+            self.useless = nn.Embedding(target_size // d_hid // 4, d_hid)
+
+        def forward(self, x):
+            x = self.net1(x)
+            x = self.relu(x)
+            x = self.net2(x)
+            x += self.useless.weight[0]
+            return x
+
+    class MultiMLP(torch.nn.Module):
+        def __init__(self, d_hid: int, n_layers: int = 2, num_classes: int = 10):
+            super().__init__()
+            self.layers = torch.nn.ModuleList(
+                [MLPModule(d_hid) for _ in range(n_layers)]
+            )
+            # Add a final classification layer
+            self.classifier = torch.nn.Linear(d_hid, num_classes)
+            # For demonstration purposes only, this should be defined by user
+            self.split_spec = {
+                f"layers.{i}": SplitPoint.BEGINNING for i in range(1, n_layers)
+            }
+
+        def forward(self, x):
+            for layer in self.layers:
+                x = layer(x)
+            # Apply the classification layer to get logits
+            x = self.classifier(x)
+            return x
+
+    n_layers = 2
+    d_hid = 128
+
+    m = MultiMLP(d_hid, n_layers).to(device)
+
+    trainset = DummyDataset(size=10000, feature_dim=d_hid)
+    trainloader = torch.utils.data.DataLoader(
+        trainset, batch_size=64, num_workers=2, shuffle=True
+    )
+
+    example_input, _ = next(iter(trainloader))
+
+    pipe = pipeline(
+        module=m, mb_args=(example_input.to(device),), split_spec=m.split_spec
+    )
+    module_partitions = [pipe.get_stage_module(idx) for idx in range(n_layers)]
+
+    inner_optimizer: optim.Optimizer = torch.optim.AdamW(
+        m.parameters(), lr=4e-4, weight_decay=0.1, betas=(0.9, 0.95)
+    )
+    outer_optimizer: optim.Optimizer = torch.optim.SGD(
+        m.parameters(), lr=0.7, momentum=0.9, nesterov=True
+    )
+
+    criterion = nn.CrossEntropyLoss()
+
+    num_params = sum(p.numel() for p in m.parameters())
+    print(f"Total number of parameters: {num_params}")
+
+    sort_by_keyword = "self_" + device + "_time_total"
+
+    def trace_handler(p):
+        p.export_chrome_trace(
+            f"/home/tushar00jain/trace_{p.step_num}_{REPLICA_GROUP_ID}.json"
+        )
+
+    # You can use an epoch based training but with faults it's easier to use step
+    # based training.
+    prof = torch.profiler.profile(
+        schedule=torch.profiler.schedule(wait=0, warmup=0, active=60, repeat=2),
+        on_trace_ready=trace_handler,
+        record_shapes=False,
+        profile_memory=False,
+    )
+
+    prof.start()
+    with DiLoCo(
+        manager,
+        module_partitions if USE_STREAMING else [m],
+        inner_optimizer,
+        outer_optimizer,
+        backup_device=device,
+        sync_every=20 if USE_STREAMING else 20,
+        fragment_sync_delay=10 if USE_STREAMING else 0,
+    ) as diloco:
+        while True:
+            for i, (inputs, labels) in enumerate(trainloader):
+                prof.step()
+
+                inputs = inputs.to(device)
+                labels = labels.to(device)
+
+                inner_optimizer.zero_grad()
+
+                out = m(inputs)
+                loss = criterion(out, labels)
+
+                loss.backward()
+
+                inner_optimizer.step()
+
+                if manager.current_step() % 100 == 0:
+                    print(f"[{manager.current_step()}] loss = {loss.item()}")
+
+                if manager.current_step() >= 50:
+                    # complete training
+                    prof.stop()
+                    exit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

## Context

- `should_commit` currently waits for all scheduled work but we need to only wait for work for a fragment
- otherwise, we need to wait for all fragments, which just makes it regular diloco

## Implementation

- removed cuda synchronize when we check errors on process group otherwise we also wait for all the work to finish on the process group
- **_instead we synchronize on the current stream but this might not be needed though because the current steam is doing training only -- @d4l3k? also baby pg doesn't override `errored()` method_**
- remove waiting on pending futures in the manager, the callers need to ensure now that they wait for the futures to complete
- had to change manager `allreduce` to support using custom streams and sprinkle event to this stream when future is ready
  - this way the users of the api can synchronize on the custom stream to make the cpu wait for the work to finish
  - it avoids exposing `Work` to users
  - this also works for baby nccl, currently it was just syncing on the main stream to wait for the allreduce work to finish

## TODO's

- removed support from quantization for now, will add it back once i make sure it works with all pg's
- unit/integration tests for streaming diloco
- tests to make sure the sync logic works as intended with all pg's


# Test Plan

- added a script `train_diloco.py` and gathered some profiles to make sure fragment send/sync happens at the right steps (using nccl)
- compare streaming vs non-streaming
- streaming performs better

## Streaming

- 2 fragments, H=10, T=5
- fragments get sent and synced at every 5 steps
- **_there's still a problem -- if there's already an allreduce in flight, a wait will block the allreduce that's issued on the current step as well. likely because there being 1 stream for networking. we need to create a separate stream for each of these allreduce to fix this. ideally nccl pg can offer an api to specify which stream users want to use_**

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/c63cfef0-5352-483b-b8b9-ffdceb294a1a" />

## Non-Streaming

- 1 fragment, H=10, T=0
- fragments get sent and synced (in the same step) at every 10 steps

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/566bd4f4-c2af-4054-84a0-e1108ce5b240" />