### PR TITLE
add streaming diloco test - recovery

### DIFF
--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -680,6 +680,9 @@ class DiLoCo:
             # Get the correct step when. This will continue after other committed.
             self._quorum_loop()
             self._should_recover = False
+            # This is to be consistent with the nodes that are not recovering. They
+            # proceed with the code below on the step after quorum completes.
+            return
 
         # We need to make sure all nodes send the same fragments in order.
         # This is to avoid deadlocking e.g.

--- a/torchft/local_sgd_test.py
+++ b/torchft/local_sgd_test.py
@@ -157,6 +157,11 @@ class DiLoCoTest(TestCase):
             loss.backward()
             inner_optimizer.step()
 
+            self.assertEqual(diloco._local_step, 0)
+            loss = model(inp).mean()
+            loss.backward()
+            inner_optimizer.step()
+
             self.assertEqual(diloco._local_step, 1)
             self.assertEqual(manager.start_quorum.call_count, 1)
             loss = model(inp).mean()
@@ -209,6 +214,10 @@ class DiLoCoTest(TestCase):
             use_bucketization=use_bucketization,
         ) as diloco:
             inp = torch.rand(2, 3)
+            loss = model(inp).mean()
+            loss.backward()
+            inner_optimizer.step()
+
             loss = model(inp).mean()
             loss.backward()
             inner_optimizer.step()

--- a/torchft/manager_integ_test.py
+++ b/torchft/manager_integ_test.py
@@ -89,7 +89,12 @@ R = TypeVar("R", covariant=True)
 
 class TrainLoop(Protocol[R]):
     def __call__(
-        self, rank: int, store_port: int, device: torch.device, runner: "Runner"
+        self,
+        rank: int,
+        store_port: int,
+        device: torch.device,
+        runner: "Runner",
+        train_loop_args: dict[str, Any] = field(default_factory=dict),
     ) -> R: ...
 
 
@@ -137,6 +142,7 @@ class Runner:
                         store_port=store.port,
                         device=device,
                         runner=self,
+                        train_loop_args=self.train_loop_args,
                     )
                 )
 
@@ -170,6 +176,7 @@ def ddp_train_loop(
     store_port: int,
     device: torch.device,
     runner: Runner,
+    train_loop_args: dict[str, Any] = {},
 ) -> Dict[str, Dict[str, object]]:
     with ExitStack() as stack:
 
@@ -525,6 +532,7 @@ def all_reduce_callback(
     store_port: int,
     device: torch.device,
     runner: Runner,
+    train_loop_args: dict[str, Any] = {},
 ) -> Optional[torch.Tensor]:
     with ExitStack() as stack:
         print(f"worker {runner.replica_id=} {rank=} {runner.world_size=} starting")


### PR DESCRIPTION

Summary:
- update diloco tests to work with model fragments
- propogate arguments for training loop and optimizer wrapper through test runner
- added a test that validates streaming diloco works when node crashes and rejoins
- store the whole manager state dict for validation instead of only user's default state dict
- fixed a bug that made the local step go out of sync

Test Plan:
```
pytest -vs ./torchft/local_sgd_integ_test.py
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchft/pull/222).
* #223
* __->__ #222