### PR TITLE
handle original parameters in diloco

### DIFF
--- a/torchft/_test/diloco_trainer.py
+++ b/torchft/_test/diloco_trainer.py
@@ -226,18 +226,6 @@ class DiLoCoTrainer:
         self.model.load_state_dict(state_dict["model"])
         self.model.to(self.device)
 
-        # Load original parameters for each fragment
-        for i, fragment in enumerate(cast(DiLoCo, self.diloco)._fragments):
-            fragment.original_parameters = cast(
-                Dict[str, torch.Tensor], state_dict["original_params"][f"{i}"]
-            )
-
-        for fragment in cast(DiLoCo, self.diloco)._fragments:
-            for name in fragment.original_parameters.keys():
-                fragment.original_parameters[name] = fragment.original_parameters[
-                    name
-                ].to(self.device)
-
         self.inner_optimizer.load_state_dict(state_dict["inner_optim"])
         for i, optimizer in enumerate(self.outer_optimizers):
             optimizer.load_state_dict(
@@ -255,10 +243,6 @@ class DiLoCoTrainer:
 
         return {
             "model": self.model.state_dict(),
-            "original_params": {
-                f"{i}": fragment.original_parameters
-                for i, fragment in enumerate(cast(DiLoCo, self.diloco)._fragments)
-            },
             "inner_optim": self.inner_optimizer.state_dict(),
             "outer_optim": {
                 f"{i}": optimizer.state_dict()

--- a/torchft/diloco_regression_test.py
+++ b/torchft/diloco_regression_test.py
@@ -204,18 +204,15 @@ class MockDiLoCoTrainer(DiLoCoTrainer):
                     # Store the manager state dict, converting to the right type
                     state_dict = copy.deepcopy(self.manager._manager_state_dict())
                     user_state_dict = cast(dict[str, object], state_dict["user"])
-                    default_state_dict = cast(
-                        dict[str, object], user_state_dict["default"]
-                    )
-                    original_params = cast(
-                        dict[str, torch.Tensor], default_state_dict["original_params"]
-                    )
                     parameter_history["global_parameter_history"][local_step] = {}
 
-                    for fragment, value in original_params.items():
-                        value = cast(dict[str, torch.Tensor], value)
+                    for i in range(self.n_fragments):
+                        value = cast(
+                            dict[str, torch.Tensor],
+                            user_state_dict[f"StreamingDiLoCoFragment_{i}"],
+                        )
                         parameter_history["global_parameter_history"][local_step][
-                            f"layers.{fragment}.weight"
+                            f"layers.{i}.weight"
                         ] = (value["weight"].data.clone().detach().cpu().tolist())
 
                     manager_steps.add(manager_curr_step)


### PR DESCRIPTION

Summary:
- external integration e.g. torchtitan don't have access to global parameters, which is diloco's internal state so they don't handle loading it or saving it
- we need to do this though so that the gradient computations can be correct when a node recovers
- set the global parameters inside diloco itself

Test Plan:
- the regression tests pass
- ran streamig diloco on 25 nodes with 1 fragment, syncing every 10 steps, with 2 step sync delay injecting failure every 7.5 minutes

<img width="922" height="287" alt="Screenshot 2025-07-18 at 4 28 57 AM" src="https://github.com/user-attachments/assets/b2ac058e-e422-4aab-9c90-e7df5666cb3f" />
