### PR TITLE
use block_current_stream work api

### DIFF
--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -373,7 +373,7 @@ class Manager:
                 )
             else:
                 work = self._pg.allreduce([tensor], ReduceOp.SUM)
-                work.wait()
+                work.block_current_stream()
                 fut = work.get_future()
 
             stream: Optional[torch.cuda.Stream] = (


### PR DESCRIPTION

Summary:
use block_current_stream to avoid blocking the cpu when using gloo

Test Plan:
## Before

<img width="1285" height="667" alt="image" src="https://github.com/user-attachments/assets/082b55ce-efac-46f8-adba-df92ffec864f" />

## After

<img width="1283" height="662" alt="image" src="https://github.com/user-attachments/assets/923bcc7b-740a-43d8-baed-19e3d77a7889" />
