### PR TITLE
option 1 - use block_current to overlap compute/communication

### DIFF
--- a/torchft/collectives.py
+++ b/torchft/collectives.py
@@ -18,6 +18,7 @@ from torch.distributed.distributed_c10d import (
     AllreduceOptions,
     AllToAllOptions,
     ReduceScatterOptions,
+    Work,
 )
 from torch.futures import Future
 
@@ -288,7 +289,7 @@ def allreduce_quantized(
     opts: AllreduceOptions | ReduceOp,
     process_group: "ProcessGroup",
     sync_stream: cuda.Stream | None = None,
-) -> Future[list[torch.Tensor]]:
+) -> Work:
     """
     Performs a quantized all-reduce operation on a list of tensors.
 
@@ -379,6 +380,14 @@ def allreduce_quantized(
             [torch.split(quantized_tensors_out.view(world_size, -1), 1)[rank]],
             _to_allgather_options(allreduce_opts),
         )
+
+        # NOTE: This is not supposed to be used with gloo, only with NCCL.
+        # So we setup the stream dependency here by calling work.wait(),
+        # which doesn't block the CPU.
+        #
+        # The future callback below will run after the work has been
+        # completed.
+
         work.wait()
         fut = work.get_future()
 
@@ -392,4 +401,4 @@ def allreduce_quantized(
                 return tensors
 
         fut = fut.then(callback)
-        return fut
+        return work

--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -94,8 +94,8 @@ else:
                     )
                 ]
 
-                fut = allreduce_quantized(tensors, reduce_op, pg)
-                fut.wait()
+                work = allreduce_quantized(tensors, reduce_op, pg)
+                work.get_future().wait()
 
                 work = pg.allreduce([expected], reduce_op)
                 work.get_future().wait()

--- a/torchft/ddp.py
+++ b/torchft/ddp.py
@@ -68,7 +68,8 @@ class DistributedDataParallel(parallel.DistributedDataParallel):
     def _comm_hook(
         state: "Manager", bucket: dist.GradBucket
     ) -> torch.futures.Future[torch.Tensor]:
-        return state.allreduce(bucket.buffer())
+        work = state.allreduce(bucket.buffer())
+        return work.get_future()
 
 
 class PureDistributedDataParallel(nn.Module):

--- a/torchft/ddp_test.py
+++ b/torchft/ddp_test.py
@@ -10,11 +10,13 @@ from unittest.mock import create_autospec
 import torch
 import torch.distributed as dist
 from torch import nn
+from torch.distributed.distributed_c10d import Work
 from torch.futures import Future
 
 from torchft.ddp import DistributedDataParallel, PureDistributedDataParallel
 from torchft.manager import Manager
 from torchft.process_group import ProcessGroupBabyGloo, ProcessGroupGloo
+from torchft.work import _DummyWork
 
 
 class TestDDP(TestCase):
@@ -39,14 +41,14 @@ class TestDDP(TestCase):
 
         call_count = 0
 
-        def allreduce(tensor: torch.Tensor) -> Future[torch.Tensor]:
+        def allreduce(
+            tensor: torch.Tensor,
+        ) -> Work:
             nonlocal call_count
 
             call_count += 1
 
-            fut = Future()  # pyre-fixme[29]: not a function
-            fut.set_result(tensor)
-            return fut
+            return _DummyWork(tensor)
 
         manager.allreduce = allreduce
 

--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type
 import torch
 import torch.distributed as dist
 from torch import nn, optim
+from torch.distributed.distributed_c10d import Work
 from torch.distributed.tensor import DTensor
 from torch.nn.parameter import Parameter
 from torch.optim.optimizer import Optimizer
@@ -154,7 +155,8 @@ class LocalSGD:
         for p in self._model.parameters():
             # Create a new tensor to store the averaged parameter
             avg_param = extract_local_tensor(p)
-            works.append(self._manager.allreduce(avg_param))
+            work = self._manager.allreduce(avg_param)
+            works.append(work)
             averaged_parameters.append(avg_param)
         for work in works:
             work.wait()
@@ -200,7 +202,7 @@ class _StreamingDiLoCoFragment:
         self._outer_optimizer = outer_optimizer
 
         # Stores pending all reduce
-        self._allreduce_futures: list[torch.futures.Future[torch.Tensor]] = []
+        self._allreduce_work: list[Work] = []
         self._stream: Optional[torch.cuda.Stream] = (
             torch.cuda.Stream() if torch.cuda.is_available() else None
         )
@@ -368,7 +370,7 @@ class _StreamingDiLoCoFragment:
         """
         Waits for the previously scheduled allreduce to finish
         """
-        if len(self._allreduce_futures) == 0:
+        if len(self._allreduce_work) == 0:
             return
 
         if self._stream is not None:
@@ -376,7 +378,7 @@ class _StreamingDiLoCoFragment:
             self._stop_event.synchronize()
             self._stop_event = None
 
-        self._allreduce_futures = []
+        self._allreduce_work = []
 
     @torch.profiler.record_function("torchft::local_sgd::prepare_sync")
     def prepare_sync(self) -> None:
@@ -399,13 +401,6 @@ class _StreamingDiLoCoFragment:
         ):
             self._average_grads()
 
-            for work in self._allreduce_futures:
-                work.wait()
-
-            if self._stream is not None:
-                self._stop_event = torch.cuda.Event()
-                self._stop_event.record()
-
     @torch.profiler.record_function("torchft::local_sgd::perform_sync")
     def perform_sync(self) -> bool:
         """
@@ -413,7 +408,19 @@ class _StreamingDiLoCoFragment:
         steps using the outer optimizer.
         """
         # Waiting for an allreduce before it has been sent is currently not supported.
-        assert len(self._allreduce_futures) > 0
+        assert len(self._allreduce_work) > 0
+
+        with (
+            torch.cuda.stream(self._stream)
+            if self._stream is not None
+            else nullcontext()
+        ):
+            for work in self._allreduce_work:
+                work.wait()
+
+            if self._stream is not None:
+                self._stop_event = torch.cuda.Event()
+                self._stop_event.record()
 
         self.wait()
 
@@ -467,7 +474,8 @@ class _StreamingDiLoCoFragment:
             work = self._manager.allreduce(
                 self._grads[name], should_quantize=self.should_quantize
             )
-            self._allreduce_futures.append(work)
+
+            self._allreduce_work.append(work)
 
     def _bucketize_and_allreduce(
         self,
@@ -508,17 +516,25 @@ class _StreamingDiLoCoFragment:
                 pack_offset += numel
                 flat_index += 1
 
-            work = self._manager.allreduce(
-                flat_buffer, should_quantize=self.should_quantize
-            )
+            with torch.cuda.stream(self._stream) if self._stream else nullcontext():
+                work = self._manager.allreduce(
+                    flat_buffer, should_quantize=self.should_quantize
+                )
 
             def callback(fut: torch.futures.Future[torch.Tensor]) -> None:
-                nonlocal bucket_tensors, flat_buffer
-                for t, pack_offset, numel in bucket_tensors:
-                    t.copy_(flat_buffer[pack_offset : pack_offset + numel].view_as(t))
+                with torch.cuda.stream(self._stream) if self._stream else nullcontext():
+                    nonlocal bucket_tensors, flat_buffer
+                    for t, pack_offset, numel in bucket_tensors:
+                        t.copy_(
+                            flat_buffer[pack_offset : pack_offset + numel].view_as(t)
+                        )
 
-            work = work.then(callback)
-            self._allreduce_futures.append(work)
+            fut = work.get_future()
+            # TODO(tushar00jain): We need to call work.wait() here to ensure callback
+            # runs after work has been completed
+            fut = fut.then(callback)
+
+            self._allreduce_work.append(work)
 
             offset += chunk_size
 

--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -520,6 +520,7 @@ class _StreamingDiLoCoFragment:
                 work = self._manager.allreduce(
                     flat_buffer, should_quantize=self.should_quantize
                 )
+                work.block_current_stream()
 
             def callback(fut: torch.futures.Future[torch.Tensor]) -> None:
                 with torch.cuda.stream(self._stream) if self._stream else nullcontext():
@@ -530,8 +531,6 @@ class _StreamingDiLoCoFragment:
                         )
 
             fut = work.get_future()
-            # TODO(tushar00jain): We need to call work.wait() here to ensure callback
-            # runs after work has been completed
             fut = fut.then(callback)
 
             self._allreduce_work.append(work)

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -386,7 +386,7 @@ class Manager:
             else:
                 work = self._pg.allreduce([tensor], ReduceOp.SUM)
 
-            # TODO(tushar00jain): Set up the stream dependency correctly
+            work.block_current_stream()
             fut = work.get_future()
 
             stream: Optional[torch.cuda.Stream] = (

--- a/torchft/manager_integ_test.py
+++ b/torchft/manager_integ_test.py
@@ -634,7 +634,7 @@ def all_reduce_callback(
 
         manager.start_quorum()
         t1 = torch.ones((1, 3), device=device)
-        fut = manager.allreduce(t1)
-        fut.wait()
+        work = manager.allreduce(t1)
+        work.get_future().wait()
         return t1
     return None

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -69,6 +69,7 @@ from torch.utils._pytree import tree_any
 from torchft.device_mesh import *  # noqa: F401
 from torchft.futures import context_timeout, stream_timeout
 from torchft.multiprocessing import _MonitoredPipe
+from torchft.work import _DummyWork
 
 if TYPE_CHECKING:
     from torchft.manager import Manager
@@ -788,21 +789,6 @@ class ProcessGroupNCCL(ProcessGroupWrapper):
 
     def getBackendName(self) -> str:
         return "torchft-nccl"
-
-
-class _DummyWork(dist._Work):
-    def __init__(self, result: object) -> None:
-        super().__init__()
-        self.result_ = result
-        # pyre-fixme[29]: Future is not a function
-        self.future_: torch.futures.Future[object] = torch.futures.Future()
-        self.future_.set_result(result)
-
-    def wait(self, timeout: Optional[timedelta] = None) -> bool:
-        return True
-
-    def get_future(self) -> torch.futures.Future[object]:
-        return self.future_
 
 
 class ProcessGroupDummy(ProcessGroup):

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1072,7 +1072,7 @@ class _ManagedWork(Work):
                 if timeout is not None:
                     self._work.wait(timeout)
                 else:
-                    self._work.wait()
+                    self._work.block_current_stream()
         except Exception as e:
             self._manager.report_error(e)
 

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -47,12 +47,12 @@ from torchft.process_group import (
     ProcessGroupGloo,
     ProcessGroupNCCL,
     ProcessGroupWrapper,
-    _DummyWork,
     _ErrorSwallowingWork,
     _ManagedWork,
     extend_device_mesh,
     ft_init_device_mesh,
 )
+from torchft.work import _DummyWork
 
 
 def dummy_init_pg() -> None:

--- a/torchft/work.py
+++ b/torchft/work.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+
+class _DummyWork(dist._Work):
+    def __init__(self, result: object) -> None:
+        super().__init__()
+        self.result_ = result
+        # pyre-fixme[29]: Future is not a function
+        self.future_: torch.futures.Future[object] = torch.futures.Future()
+        self.future_.set_result(result)
+
+    def wait(self, timeout: Optional[timedelta] = None) -> bool:
+        return True
+
+    def get_future(self) -> torch.futures.Future[object]:
+        return self.future_

--- a/train_diloco.py
+++ b/train_diloco.py
@@ -34,7 +34,7 @@ from torchft import (
     ProcessGroupGloo,
     ProcessGroupNCCL,
 )
-from torchft.checkpointing.pg_transport import PGTransport
+from torchft.checkpointing.http_transport import HTTPTransport
 from torchft.local_sgd import DiLoCo
 
 logging.basicConfig(level=logging.INFO)
@@ -67,13 +67,12 @@ def main() -> None:
             timeout=timedelta(seconds=10),
         )
         if torch.cuda.is_available() and USE_NCCL
-        else ProcessGroupGloo(timeout=timedelta(seconds=5))
+        else ProcessGroupGloo(timeout=timedelta(seconds=10))
     )
 
-    transport = PGTransport(
-        pg,
+    transport = HTTPTransport(
         timeout=timedelta(seconds=10),
-        device=device,
+        num_chunks=0,
     )
 
     manager = Manager(


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchft/pull/243).
* __->__ #243
* #240