### PR TITLE
return work from manager allreduce

### DIFF
--- a/torchft/collectives.py
+++ b/torchft/collectives.py
@@ -387,6 +387,8 @@ def allreduce_quantized(
             nonlocal tensors, quantized_tensors, world_size, sync_stream
 
             with torch.cuda.stream(sync_stream):
+                # Setup stream dependency
+                fut.wait()
                 # Dequantize the result back to the original precision
                 fused_dequantize_from_fp8(tensors, quantized_tensors, world_size)
                 return tensors

--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -94,8 +94,8 @@ else:
                     )
                 ]
 
-                fut = allreduce_quantized(tensors, reduce_op, pg)
-                fut.wait()
+                work = allreduce_quantized(tensors, reduce_op, pg)
+                work.wait()
 
                 work = pg.allreduce([expected], reduce_op)
                 work.get_future().wait()

--- a/torchft/ddp.py
+++ b/torchft/ddp.py
@@ -68,7 +68,8 @@ class DistributedDataParallel(parallel.DistributedDataParallel):
     def _comm_hook(
         state: "Manager", bucket: dist.GradBucket
     ) -> torch.futures.Future[torch.Tensor]:
-        return state.allreduce(bucket.buffer())
+        work = state.allreduce(bucket.buffer())
+        return work.get_future()
 
 
 class PureDistributedDataParallel(nn.Module):

--- a/torchft/ddp_test.py
+++ b/torchft/ddp_test.py
@@ -10,11 +10,13 @@ from unittest.mock import create_autospec
 import torch
 import torch.distributed as dist
 from torch import nn
+from torch.distributed.distributed_c10d import Work
 from torch.futures import Future
 
 from torchft.ddp import DistributedDataParallel, PureDistributedDataParallel
 from torchft.manager import Manager
 from torchft.process_group import ProcessGroupBabyGloo, ProcessGroupGloo
+from torchft.work import _DummyWork
 
 
 class TestDDP(TestCase):
@@ -39,14 +41,14 @@ class TestDDP(TestCase):
 
         call_count = 0
 
-        def allreduce(tensor: torch.Tensor) -> Future[torch.Tensor]:
+        def allreduce(
+            tensor: torch.Tensor,
+        ) -> Work:
             nonlocal call_count
 
             call_count += 1
 
-            fut = Future()  # pyre-fixme[29]: not a function
-            fut.set_result(tensor)
-            return fut
+            return _DummyWork(tensor)
 
         manager.allreduce = allreduce
 

--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type
 import torch
 import torch.distributed as dist
 from torch import nn, optim
+from torch.distributed.distributed_c10d import Work
 from torch.distributed.tensor import DTensor
 from torch.nn.parameter import Parameter
 from torch.optim.optimizer import Optimizer
@@ -200,7 +201,7 @@ class _StreamingDiLoCoFragment:
         self._outer_optimizer = outer_optimizer
 
         # Stores pending all reduce
-        self._allreduce_futures: list[torch.futures.Future[torch.Tensor]] = []
+        self._allreduce_work: list[Work] = []
         self._stream: Optional[torch.cuda.Stream] = (
             torch.cuda.Stream() if torch.cuda.is_available() else None
         )
@@ -368,7 +369,7 @@ class _StreamingDiLoCoFragment:
         """
         Waits for the previously scheduled allreduce to finish
         """
-        if len(self._allreduce_futures) == 0:
+        if len(self._allreduce_work) == 0:
             return
 
         if self._stream is not None:
@@ -376,7 +377,7 @@ class _StreamingDiLoCoFragment:
             self._stop_event.synchronize()
             self._stop_event = None
 
-        self._allreduce_futures = []
+        self._allreduce_work = []
 
     @torch.profiler.record_function("torchft::local_sgd::prepare_sync")
     def prepare_sync(self) -> None:
@@ -386,7 +387,7 @@ class _StreamingDiLoCoFragment:
         """
         self._save_grads()
 
-        assert len(self._allreduce_futures) == 0
+        assert len(self._allreduce_work) == 0
 
         # Make sure tensors are available to `_stream`
         if self._stream is not None:
@@ -399,7 +400,7 @@ class _StreamingDiLoCoFragment:
         ):
             self._average_grads()
 
-            for work in self._allreduce_futures:
+            for work in self._allreduce_work:
                 work.wait()
 
             if self._stream is not None:
@@ -413,7 +414,7 @@ class _StreamingDiLoCoFragment:
         steps using the outer optimizer.
         """
         # Waiting for an allreduce before it has been sent is currently not supported.
-        assert len(self._allreduce_futures) > 0
+        assert len(self._allreduce_work) > 0
 
         self.wait()
 
@@ -467,7 +468,8 @@ class _StreamingDiLoCoFragment:
             work = self._manager.allreduce(
                 self._grads[name], should_quantize=self.should_quantize
             )
-            self._allreduce_futures.append(work)
+
+            self._allreduce_work.append(work)
 
     def _bucketize_and_allreduce(
         self,
@@ -522,8 +524,10 @@ class _StreamingDiLoCoFragment:
                             flat_buffer[pack_offset : pack_offset + numel].view_as(t)
                         )
 
-            work = work.then(callback)
-            self._allreduce_futures.append(work)
+            fut = work.get_future()
+            fut.add_done_callback(callback)
+
+            self._allreduce_work.append(work)
 
             offset += chunk_size
 

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -403,6 +403,8 @@ class Manager:
                 # change the stream to avoid making the callback stream
                 # dependent on process group stream running the allreduce
                 with torch.cuda.stream(stream) if stream is not None else nullcontext():
+                    # Setup stream dependency
+                    fut.wait()
                     fut.value()
                     tensor /= num_participants
 

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -39,11 +39,12 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar, 
 
 import torch
 from torch.distributed import ReduceOp, TCPStore
-from torch.distributed.distributed_c10d import AllreduceOptions, ReduceOp
+from torch.distributed.distributed_c10d import AllreduceOptions, ReduceOp, Work
 
 from torchft._torchft import ManagerClient, ManagerServer
 from torchft.checkpointing import CheckpointTransport, HTTPTransport
 from torchft.futures import future_timeout
+from torchft.work import _DummyWork, _WorkWrapper
 
 if TYPE_CHECKING:
     from torchft.process_group import ProcessGroup
@@ -343,9 +344,7 @@ class Manager:
         self._executor.shutdown(wait=wait)
 
     @torch.profiler.record_function("torchft::manager::allreduce")
-    def allreduce(
-        self, tensor: torch.Tensor, should_quantize: bool = False
-    ) -> torch.futures.Future[torch.Tensor]:
+    def allreduce(self, tensor: torch.Tensor, should_quantize: bool = False) -> Work:
         """
         Fault tolerant allreduce the tensor and return a Future that will be completed when
         the tensor is ready.
@@ -365,9 +364,7 @@ class Manager:
             a Future that will be completed with the allreduced tensor
         """
         if self.errored():
-            fut = torch.futures.Future()  # pyre-fixme[29]: not a function
-            fut.set_result(tensor)
-            return fut
+            return _DummyWork(tensor)
 
         self.wait_quorum()
         num_participants: int = self.num_participants()
@@ -380,13 +377,14 @@ class Manager:
             # Run the allreduce async and save the work object so we can wait on
             # it later.
             if should_quantize and IS_TRITON_AVAILABLE:
-                fut = allreduce_quantized(
+                work = allreduce_quantized(
                     [tensor], ReduceOp.SUM, self._pg, torch.cuda.current_stream()
                 )
             else:
                 work = self._pg.allreduce([tensor], ReduceOp.SUM)
                 work.wait()
-                fut = work.get_future()
+
+            fut = work.get_future()
 
             stream: Optional[torch.cuda.Stream] = (
                 torch.cuda.current_stream() if torch.cuda.is_available() else None
@@ -413,7 +411,8 @@ class Manager:
             fut = fut.then(callback)
 
             fut = self.wrap_future(fut, tensor)
-            return fut
+
+            return _WorkWrapper(work, fut)
 
         except Exception as e:
             self._logger.exception(
@@ -421,9 +420,7 @@ class Manager:
             )
             self.report_error(e)
 
-            fut = torch.futures.Future()  # pyre-fixme[29]: not a function
-            fut.set_result(tensor)
-            return fut
+            return _DummyWork(tensor)
 
     def report_error(self, e: Exception) -> None:
         """

--- a/torchft/manager_integ_test.py
+++ b/torchft/manager_integ_test.py
@@ -634,7 +634,7 @@ def all_reduce_callback(
 
         manager.start_quorum()
         t1 = torch.ones((1, 3), device=device)
-        fut = manager.allreduce(t1)
-        fut.wait()
+        work = manager.allreduce(t1)
+        work.wait()
         return t1
     return None

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -69,6 +69,7 @@ from torch.utils._pytree import tree_any
 from torchft.device_mesh import *  # noqa: F401
 from torchft.futures import context_timeout, stream_timeout
 from torchft.multiprocessing import _MonitoredPipe
+from torchft.work import _DummyWork
 
 if TYPE_CHECKING:
     from torchft.manager import Manager
@@ -788,21 +789,6 @@ class ProcessGroupNCCL(ProcessGroupWrapper):
 
     def getBackendName(self) -> str:
         return "torchft-nccl"
-
-
-class _DummyWork(dist._Work):
-    def __init__(self, result: object) -> None:
-        super().__init__()
-        self.result_ = result
-        # pyre-fixme[29]: Future is not a function
-        self.future_: torch.futures.Future[object] = torch.futures.Future()
-        self.future_.set_result(result)
-
-    def wait(self, timeout: Optional[timedelta] = None) -> bool:
-        return True
-
-    def get_future(self) -> torch.futures.Future[object]:
-        return self.future_
 
 
 class ProcessGroupDummy(ProcessGroup):

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -47,12 +47,12 @@ from torchft.process_group import (
     ProcessGroupGloo,
     ProcessGroupNCCL,
     ProcessGroupWrapper,
-    _DummyWork,
     _ErrorSwallowingWork,
     _ManagedWork,
     extend_device_mesh,
     ft_init_device_mesh,
 )
+from torchft.work import _DummyWork
 
 
 def dummy_init_pg() -> None:

--- a/torchft/work.py
+++ b/torchft/work.py
@@ -1,0 +1,37 @@
+from contextlib import nullcontext
+from datetime import timedelta
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+
+class _DummyWork(dist._Work):
+    def __init__(self, result: object) -> None:
+        super().__init__()
+        self.result_ = result
+        # pyre-fixme[29]: Future is not a function
+        self.future_: torch.futures.Future[object] = torch.futures.Future()
+        self.future_.set_result(result)
+
+    def wait(self, timeout: Optional[timedelta] = None) -> bool:
+        return True
+
+    def get_future(self) -> torch.futures.Future[object]:
+        return self.future_
+
+
+class _WorkWrapper(dist._Work):
+    def __init__(
+        self, work: dist._Work, fut: torch.futures.Future[torch.Tensor]
+    ) -> None:
+        super().__init__()
+        self._work = work
+        self._fut = fut
+
+    def wait(self, timeout: Optional[timedelta] = None) -> bool:
+        self._fut.wait()
+        return True
+
+    def get_future(self) -> torch.futures.Future[torch.Tensor]:
+        return self._fut

--- a/train_diloco.py
+++ b/train_diloco.py
@@ -34,7 +34,7 @@ from torchft import (
     ProcessGroupGloo,
     ProcessGroupNCCL,
 )
-from torchft.checkpointing.pg_transport import PGTransport
+from torchft.checkpointing.http_transport import HTTPTransport
 from torchft.local_sgd import DiLoCo
 
 logging.basicConfig(level=logging.INFO)
@@ -67,13 +67,12 @@ def main() -> None:
             timeout=timedelta(seconds=10),
         )
         if torch.cuda.is_available() and USE_NCCL
-        else ProcessGroupGloo(timeout=timedelta(seconds=5))
+        else ProcessGroupGloo(timeout=timedelta(seconds=10))
     )
 
-    transport = PGTransport(
-        pg,
+    transport = HTTPTransport(
         timeout=timedelta(seconds=10),
-        device=device,
+        num_chunks=0,
     )
 
     manager = Manager(


### PR DESCRIPTION

Summary:
returns the work object so we can be more flexible with the usage

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchft/pull/247).
* #249
* #240
* #248
* #245
* #243
* __->__ #247
* #246
* #244