### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Easy Per Step Fault Tolerance for PyTorch
 
 <p align="center">
   | <a href="https://pytorch.org/torchft/"><b>Documentation</b></a>
-  | <a href="https://github.com/pytorch-labs/torchft/blob/main/media/fault_tolerance_poster.pdf"><b>Poster</b></a>
+  | <a href="https://github.com/meta-pytorch/torchft/blob/main/media/fault_tolerance_poster.pdf"><b>Poster</b></a>
   | <a href="https://docs.google.com/document/d/1OZsOsz34gRDSxYXiKkj4WqcD9x0lP9TcsfBeu_SsOY4/edit"><b>Design Doc</b></a>
   |
 </p>

--- a/docs/source/assumptions_and_recommendations.rst
+++ b/docs/source/assumptions_and_recommendations.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/pytorch-labs/torchft/assumptions-and-recommendations
+:github_url: https://github.com/meta-pytorch/torchft/assumptions-and-recommendations
 
 Assumptions and Recommendations
 ===============================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ FBCODE = "fbcode" in os.getcwd()
 #
 needs_sphinx = "1.6"
 
-user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0 github.com/pytorch-labs/torchft"
+user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0 github.com/meta-pytorch/torchft"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/pytorch-labs/torchft
+:github_url: https://github.com/meta-pytorch/torchft
 
 torchft
 ========
@@ -7,7 +7,7 @@ This repository implements primitives and E2E solutions for doing a per-step
 fault tolerance so you can keep training if errors occur without interrupting
 the entire training job.
 
-**GETTING STARTED?** See Install and Usage in `the README <https://github.com/pytorch-labs/torchft>`_.
+**GETTING STARTED?** See Install and Usage in `the README <https://github.com/meta-pytorch/torchft>`_.
 
 .. toctree::
     :maxdepth: 1
@@ -26,7 +26,7 @@ the entire training job.
 License
 ---------
 
-torchft is BSD 3-Clause licensed. See `LICENSE <https://github.com/pytorch-labs/torchft/blob/main/LICENSE>`_ for more details.
+torchft is BSD 3-Clause licensed. See `LICENSE <https://github.com/meta-pytorch/torchft/blob/main/LICENSE>`_ for more details.
 
 Copyright © Meta Platforms, Inc
 

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/pytorch-labs/torchft/protocol
+:github_url: https://github.com/meta-pytorch/torchft/protocol
 
 Protocol
 ========


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Only modified files with extensions: .py, .md, .sh, .rst, .cpp, .h, .txt, .yml
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-12T20:57:53.861336+00:00Z