### PR TITLE
Add monarch+torchft distributed training example

### DIFF
--- a/examples/monarch/README.md
+++ b/examples/monarch/README.md
@@ -1,0 +1,50 @@
+Monarch-TorchFT-TorchTitan Distributed Training Orchestrator
+
+This script orchestrates fault-tolerant distributed training using TorchTitan and TorchMonarch
+frameworks. It manages multiple training replicas across SLURM-scheduled compute nodes
+with automatic failure recovery and TorchFT lighthouse coordination.
+
+PREREQUISITES:
+- Access to a SLURM cluster with GPU nodes
+- Environment with nightly TorchFT, TorchTitan, and Monarch libraries installed.
+- TorchTitan training configuration file in script directory (debug_model.toml)
+- A training dataset (c4_test) and tokenizer in script directory
+
+CONFIGURATION:
+Before running, update the cluster-specific constants:
+- MACHINE: TorchX named resource for your cluster (currently: "gpu.xlarge")
+- MACHINE_MEMORY: Memory per machine in MB (currently: 2062607)
+You can also override the resource configuration manually:
+- https://docs.pytorch.org/torchx/main/specs.html#resource
+
+USAGE:
+    python train_distributed.py --help
+
+    Basic usage with 2 replicas, each with 1 node and 8 GPUs:
+        python train_distributed.py
+
+    Custom configuration:
+        python train_distributed.py --replica-count 3 --gpu-per-node 8 \
+            --host-per-replica 2 --training-steps 100
+
+    With remote TorchFT lighthouse:
+        python train_distributed.py --remote-lighthouse
+
+KEY COMPONENTS:
+- LighthouseActor: Coordination server for fault tolerance
+- TrainingActor: Individual trainer processes
+- ReplicaActor: Manages groups of trainers
+- OrchestrationManager: Top-level orchestration and failure recovery
+
+FAILURE RECOVERY:
+- Automatic replica retry with configurable delays (PER_ATTEMPT_DELAY)
+- New allocations after repeated failures (PROC_ATTEMPTS)
+- Maximum attempts per replica (MAX_ATTEMPT)
+
+OUTPUT:
+- Training outputs saved to ./outputs directory
+- Logs streamed from all distributed processes
+- TensorBoard metrics enabled by default
+
+CLEANUP:
+All SLURM jobs are automatically terminated at script completion.

--- a/examples/monarch/README.md
+++ b/examples/monarch/README.md
@@ -1,23 +1,23 @@
-Monarch-TorchFT-TorchTitan Distributed Training Orchestrator
+### Monarch-TorchFT-TorchTitan Distributed Training Orchestrator
 
+#### Overview 
 This script orchestrates fault-tolerant distributed training using TorchTitan and TorchMonarch
 frameworks. It manages multiple training replicas across SLURM-scheduled compute nodes
 with automatic failure recovery and TorchFT lighthouse coordination.
 
-PREREQUISITES:
+##### PREREQUISITES
 - Access to a SLURM cluster with GPU nodes
-- Environment with nightly TorchFT, TorchTitan, and Monarch libraries installed.
 - TorchTitan training configuration file in script directory (debug_model.toml)
 - A training dataset (c4_test) and tokenizer in script directory
 
-CONFIGURATION:
+##### CONFIGURATION
 Before running, update the cluster-specific constants:
 - MACHINE: TorchX named resource for your cluster (currently: "gpu.xlarge")
 - MACHINE_MEMORY: Memory per machine in MB (currently: 2062607)
 You can also override the resource configuration manually:
 - https://docs.pytorch.org/torchx/main/specs.html#resource
 
-USAGE:
+##### USAGE
     python train_distributed.py --help
 
     Basic usage with 2 replicas, each with 1 node and 8 GPUs:
@@ -30,21 +30,21 @@ USAGE:
     With remote TorchFT lighthouse:
         python train_distributed.py --remote-lighthouse
 
-KEY COMPONENTS:
+##### KEY COMPONENTS
 - LighthouseActor: Coordination server for fault tolerance
 - TrainingActor: Individual trainer processes
 - ReplicaActor: Manages groups of trainers
 - OrchestrationManager: Top-level orchestration and failure recovery
 
-FAILURE RECOVERY:
-- Automatic replica retry with configurable delays (PER_ATTEMPT_DELAY)
+##### FAILURE RECOVERY
+- Automatic retry with configurable delays (PER_ATTEMPT_DELAY)
 - New allocations after repeated failures (PROC_ATTEMPTS)
 - Maximum attempts per replica (MAX_ATTEMPT)
 
-OUTPUT:
+##### OUTPUT
 - Training outputs saved to ./outputs directory
 - Logs streamed from all distributed processes
 - TensorBoard metrics enabled by default
 
-CLEANUP:
+##### CLEANUP
 All SLURM jobs are automatically terminated at script completion.

--- a/examples/monarch/train_distributed.py
+++ b/examples/monarch/train_distributed.py
@@ -1,0 +1,420 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import argparse
+import asyncio
+import os
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Dict
+import atexit
+
+import torch
+
+from monarch._rust_bindings.monarch_hyperactor.alloc import AllocConstraints, AllocSpec
+from monarch._src.actor.allocator import RemoteAllocator, TorchXRemoteAllocInitializer
+from monarch.actor import Actor, current_rank, endpoint, ProcMesh, this_host
+from monarch.tools import commands
+from monarch.tools.components import hyperactor
+from monarch.tools.config import Config
+from monarch.utils import setup_env_for_distributed
+
+from torchtitan.config import ConfigManager, JobConfig
+from torchtitan.tools.logging import init_logger, logger
+from torchtitan.train import Trainer
+
+
+# ==== Allocation boilerplate - much of this will be upstreamed into Monarch ====
+class MonarchSlurm:
+    # Cluster Configuration - update these values for your specific cluster
+    machine: str = "aws_g5.12xlarge"
+    machine_memory: int = 186777
+    job_name_prefix: str = "monarch-torchft"
+
+    job_handles: Dict[str, str] = {}
+
+    @classmethod
+    def get_config(cls, mesh_name: str, nodes_per_mesh: int) -> Config:
+        mesh = [f"{mesh_name}:{nodes_per_mesh}:{MonarchSlurm.machine}"]
+        appdef = hyperactor.host_mesh(meshes=mesh)
+
+        for role in appdef.roles:
+            role.resource.memMB = MonarchSlurm.machine_memory
+
+        return Config(scheduler="slurm", appdef=appdef)
+
+    @classmethod
+    async def get_or_create_job(cls, mesh_name: str, nodes_per_mesh: int = 1) -> None:
+        config = cls.get_config(mesh_name, nodes_per_mesh)
+        job_name = f"{MonarchSlurm.job_name_prefix}-{mesh_name}"
+        server_spec = await commands.get_or_create(job_name, config, force_restart=True)
+        cls.job_handles[mesh_name] = server_spec.name
+
+    @classmethod
+    def kill_jobs(cls):
+        for mesh_name, job_handle in cls.job_handles.items():
+            try:
+                logger.info(f"Destroying job for mesh {mesh_name}")
+                commands.kill(f"slurm:///{job_handle}")
+            except Exception as e:
+                logger.warning(f"Failed to destroy job for {mesh_name}: {e}")
+
+    @classmethod
+    def proc_mesh(
+        cls,
+        mesh_name: str,
+        num_hosts: int = 1,
+        num_gpus: int = 8,
+    ) -> ProcMesh:
+        allocator = RemoteAllocator(
+            world_id=MonarchSlurm.job_name_prefix,
+            initializer=TorchXRemoteAllocInitializer(f"slurm:///{cls.job_handles[mesh_name]}"),
+        )
+        alloc = allocator.allocate(
+            AllocSpec(AllocConstraints(), hosts=num_hosts, gpus=num_gpus)
+        )
+
+        return ProcMesh.from_alloc(alloc)
+
+
+# ==== allocation boilerplate ====
+
+class LighthouseActor(Actor):
+    def __init__(self) -> None:
+        self.lighthouse = None
+
+    @endpoint
+    def start_lighthouse(self) -> str:
+        from torchft.coordination import LighthouseServer
+        self.lighthouse = LighthouseServer(
+            bind="[::]:0", min_replicas=1, join_timeout_ms=10000
+        )
+        return self.lighthouse.address()
+
+    @endpoint
+    def stop_lighthouse(self) -> None:
+        if not self.lighthouse:
+            raise RuntimeError("Lighthouse not started!")
+        self.lighthouse.shutdown()
+
+
+class TrainingActor(Actor):
+    def __init__(self, job_config: JobConfig, replica_id: int) -> None:
+        self.job_config = job_config
+        rank = current_rank().rank
+        self.uid = f"[replica_{replica_id}_trainer_{rank}]"
+
+    @endpoint
+    async def start_training(self, lighthouse_address: str) -> None:
+        init_logger()
+
+        os.environ["TORCHFT_LIGHTHOUSE"] = lighthouse_address
+        trainer = Trainer(self.job_config)
+        logger.info(f"{self.uid} initialized successfully on {os.getpid()}")
+
+        try:
+            logger.info(f"{self.uid} starting training")
+            trainer.train()
+        except Exception:
+            if trainer:
+                trainer.close()
+            raise
+        else:
+            trainer.close()
+        finally:
+            torch.distributed.destroy_process_group()
+            logger.info(f"{self.uid} trainer cleaned up")
+
+
+@dataclass
+class JobSpec:
+    job_config: JobConfig
+    remote_lighthouse: bool
+    replica_count: int
+    hosts_per_replica: int
+    gpus_per_node: int
+    lighthouse_address: str = ""
+
+
+@dataclass
+class Replica:
+    rid: int
+    proc_mesh: ProcMesh
+    actor: "ReplicaActor"
+    attempt_number: int = 0
+
+
+# This does not currently benefit from being an actor, but will once
+# Monarch supervision APIs are fleshed out.
+class ReplicaActor(Actor):
+    def __init__(
+        self,
+        spec: JobSpec,
+        replica_id: int,
+    ) -> None:
+        self.spec = deepcopy(spec)
+        self.replica_id = replica_id
+
+        self.uid = f"[replica_{replica_id}]"
+        self.spec.job_config.fault_tolerance.replica_id = self.replica_id
+
+    @endpoint
+    async def start_replica(self) -> None:
+        init_logger()
+        logger.info(f"{self.uid} Spawning trainers")
+
+        trainers_proc_mesh: ProcMesh | None = None
+        try:
+            trainers_proc_mesh = MonarchSlurm.proc_mesh(
+                f"replica_{self.replica_id}",
+                self.spec.hosts_per_replica,
+                self.spec.gpus_per_node,
+            )
+            await trainers_proc_mesh.logging_option(
+                stream_to_client=True, aggregate_window_sec=None
+            )
+            await setup_env_for_distributed(trainers_proc_mesh)
+
+            training_actors = trainers_proc_mesh.spawn(
+                "training_actors",
+                TrainingActor,
+                self.spec.job_config,
+                self.replica_id,
+            )
+
+            logger.info(f"{self.uid} Starting trainers")
+            await training_actors.start_training.call(self.spec.lighthouse_address)
+            await trainers_proc_mesh.stop()
+        except Exception as e:
+            if trainers_proc_mesh:
+                await trainers_proc_mesh.stop()
+            raise e
+
+
+# delay before re-creating proc mesh on existing job. change as needed.
+PROC_ATTEMPT_DELAY = 10
+# proc attempts before getting a new scheduler allocation. change as needed.
+PROC_ATTEMPTS = 2
+# attempts before failing training on replica. change as needed.
+MAX_ATTEMPT = PROC_ATTEMPTS * 2
+
+
+class OrchestrationManager:
+    def __init__(self, spec: JobSpec) -> None:
+        self.spec = spec
+        self.replicas: Dict[int, Replica] = {}
+        self.lighthouse_actor: LighthouseActor | None = None
+        self.lighthouse_mesh: ProcMesh | None = None
+
+    async def start_training(self) -> None:
+        logger.info(
+            f"[Controller] Creating training system with {self.spec.replica_count} replicas"
+        )
+
+        for replica_id in range(self.spec.replica_count):
+            await MonarchSlurm.get_or_create_job(f"replica_{replica_id}", self.spec.hosts_per_replica)
+
+        mesh_futures = {}
+        for i in range(self.spec.replica_count):
+            mesh_futures[i] = asyncio.create_task(self._run_replica(i, 0))
+
+        await asyncio.gather(*mesh_futures.values(), return_exceptions=True)
+
+    async def start_lighthouse(self) -> None:
+        if self.spec.remote_lighthouse:
+            await MonarchSlurm.get_or_create_job("lighthouse")
+            self.lighthouse_mesh = MonarchSlurm.proc_mesh("lighthouse", num_gpus=1)
+        else:
+            self.lighthouse_mesh = this_host().spawn_procs({"gpus": 1})
+
+        await self.lighthouse_mesh.logging_option(
+            stream_to_client=True, aggregate_window_sec=None
+        )
+        self.lighthouse_actor = self.lighthouse_mesh.spawn(
+            "lighthouse_actor", LighthouseActor
+        )
+        self.spec.lighthouse_address = (
+            await self.lighthouse_actor.start_lighthouse.call_one()
+        )
+
+    async def stop_lighthouse(self) -> None:
+        try:
+            if self.lighthouse_mesh:
+                await self.lighthouse_actor.stop_lighthouse.call_one()
+                await self.lighthouse_mesh.stop()
+            logger.info("[Controller] Lighthouse stopped")
+        except Exception as e:
+            logger.warning(f"[Controller] Failed to stop lighthouse: {e}")
+
+    async def _run_replica(self, replica_id: int, attempt_number: int) -> None:
+        if attempt_number >= MAX_ATTEMPT:
+            logger.info(f"[Controller] Replica {replica_id} has failed too many times.")
+            return
+
+        try:
+            await self._spin_up_replica(replica_id, attempt_number)
+            logger.info(f"[Controller] replica {replica_id} done")
+            await self._teardown(replica_id)
+        except Exception as e:
+            await self._teardown(replica_id)
+            logger.info(f"[Controller] replica {replica_id} failed: {e}")
+            await self._run_replica(replica_id, attempt_number + 1)
+
+    async def _spin_up_replica(self, replica_id: int, attempt_number: int = 0) -> None:
+        if attempt_number != 0 and attempt_number % PROC_ATTEMPTS == 0:
+            logger.info(
+                f"[Controller] Replica {replica_id} has failed {attempt_number} times. Getting new allocation."
+            )
+            await MonarchSlurm.get_or_create_job(
+                f"replica_{replica_id}", self.spec.hosts_per_replica
+            )
+        delay = 0 if not attempt_number else PROC_ATTEMPT_DELAY
+        logger.info(
+            f"[Controller] Spinning up replica with ID {replica_id} in {delay} seconds"
+        )
+        await asyncio.sleep(delay)
+
+        replica_proc_mesh = this_host().spawn_procs({"gpus": 1})
+        await replica_proc_mesh.logging_option(aggregate_window_sec=None)
+
+        replica_actor = replica_proc_mesh.spawn(
+            "replica_actor",
+            ReplicaActor,
+            self.spec,
+            replica_id,
+        )
+
+        replica = Replica(replica_id, replica_proc_mesh, replica_actor, attempt_number)
+        self.replicas[replica_id] = replica
+        await replica.actor.start_replica.call_one()
+
+    async def _teardown(self, replica_id: int) -> None:
+        try:
+            replica = self.replicas[replica_id]
+            await replica.proc_mesh.stop()
+            del replica.proc_mesh
+            del self.replicas[replica_id]
+        except Exception as e:
+            logger.error(f"[Controller] Failed to _teardown replica {replica_id}: {e}")
+
+
+# === CLI / CONFIG === #
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Monarch-TorchFT Distributed Training Example"
+    )
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    parser.add_argument(
+        "--replica-count", type=int, default=2, help="Number of replicas (default: 2)"
+    )
+    parser.add_argument(
+        "--gpu-per-node", type=int, default=8, help="GPUs per replica (default: 8)"
+    )
+    parser.add_argument(
+        "--host-per-replica", type=int, default=1, help="Hosts per replica (default: 1)"
+    )
+    parser.add_argument(
+        "--remote-lighthouse",
+        action="store_true",
+        help="Run the LighthouseServer on a worker node (default: False)",
+    )
+    parser.add_argument(
+        "--training-steps",
+        type=int,
+        default=50,
+        help="Number of training steps (default: 50)",
+    )
+    parser.add_argument(
+        "--model-config",
+        type=str,
+        default=os.path.join(script_dir, "debug_model.toml"),
+        help=f"Path to model configuration file (default: {os.path.join(script_dir, 'debug_model.toml')})",
+    )
+    parser.add_argument(
+        "--dataset-path",
+        type=str,
+        default=os.path.join(script_dir, "c4_test"),
+        help=f"Path to training dataset (default: {os.path.join(script_dir, 'c4_test')})",
+    )
+    parser.add_argument(
+        "--tokenizer-path",
+        type=str,
+        default=os.path.join(script_dir, "tokenizer"),
+        help=f"Path to tokenizer (default: {os.path.join(script_dir, 'tokenizer')})",
+    )
+
+    return parser.parse_args()
+
+
+def make_job_spec(args: argparse.Namespace) -> JobSpec:
+    data_parallel_shard_degree = args.gpu_per_node * args.host_per_replica
+
+    output_path = "./outputs"
+    training_dataset = "c4_test"
+
+    default_args = [
+        "--job.config_file",
+        args.model_config,
+        "--model.tokenizer_path",
+        args.tokenizer_path,
+        "--comm.trace_buf_size",
+        "0",
+        "--metrics.log_freq",
+        "1",
+        "--fault_tolerance.enable",
+        "--fault_tolerance.group_size",
+        str(args.replica_count),
+        "--parallelism.data_parallel_shard_degree",
+        str(data_parallel_shard_degree),
+        "--activation_checkpoint.mode",
+        "full",
+        "--comm.train_timeout_seconds",
+        "60",
+        "--training.steps",
+        str(args.training_steps),
+        "--training.dataset",
+        training_dataset,
+        "--training.dataset_path",
+        args.dataset_path,
+        "--job.dump_folder",
+        output_path,
+        "--metrics.enable_tensorboard",
+    ]
+
+    config_manager = ConfigManager()
+    job_config = config_manager.parse_args(default_args)
+
+    return JobSpec(
+        job_config=job_config,
+        remote_lighthouse=args.remote_lighthouse,
+        replica_count=args.replica_count,
+        hosts_per_replica=args.host_per_replica,
+        gpus_per_node=args.gpu_per_node,
+    )
+# === CLI / CONFIG === #
+
+
+async def main() -> None:
+    init_logger()
+
+    args = parse_args()
+    job_spec = make_job_spec(args)
+
+    atexit.register(MonarchSlurm.kill_jobs)
+    orchestrator = OrchestrationManager(job_spec)
+    try:
+        await orchestrator.start_lighthouse()
+        await orchestrator.start_training()
+    finally:
+        await orchestrator.stop_lighthouse()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
README should provide all necessary context for the script. We plan to iterate from here to add the following:

1. Cleanup of allocator logic once it is upstreamed in Monarch
2. Support for hot spares / host-level supervision
3. We could consider adding TrainerActor and a fleshed out ReplicaActor (with host supervision) to the library once they are in a more complete state, so that they are easily accessible to users.